### PR TITLE
簡単なマルチクライアント対応のIRCサーバーの実装

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -1,0 +1,46 @@
+#ifndef SERVER_HPP
+# define SERVER_HPP
+
+#include <unistd.h>
+#include <cstdlib>
+#include <cstring>
+#include <cerrno>
+#include <iostream>
+#include <vector>
+#include <map>
+#include <string>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/poll.h>
+
+#define PORT 6667
+#define MAX_CLIENTS 10
+#define BUF_SIZE 512
+
+class Server
+{
+
+public:
+	
+	Server(int port);
+	~Server();
+
+	void	run(void);
+
+private:
+
+	int							_server_fd;
+	struct sockaddr_in			_server_addr;
+
+	std::vector<struct pollfd>	_poll_fds;
+	std::map<int, std::string>	_client_buffers;
+
+	void	acceptNewClient(void);
+	void	handleClientInput(int fd);
+	void	broadcast(int sender_fd, std::string const & msg);
+	void	removeClient(int fd);
+	void	exitError(std::string const & error_msg);
+
+};
+
+#endif

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,0 +1,135 @@
+#include "Server.hpp"
+
+Server::Server(int port)
+{
+	_server_fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (_server_fd < 0)
+		exitError("socket: ");
+
+	int	opt = 1;
+	setsockopt(_server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+	std::memset(&_server_addr, 0, sizeof(_server_addr));
+	_server_addr.sin_family = AF_INET;
+	_server_addr.sin_addr.s_addr = INADDR_ANY;
+	_server_addr.sin_port = htons(port);
+
+	if (bind(_server_fd, (struct sockaddr *)&_server_addr, sizeof(_server_addr)) < 0)
+		exitError("bind: ");
+	if (listen(_server_fd, MAX_CLIENTS))
+		exitError("listen: ");
+
+	struct pollfd pfd;
+	pfd.fd = _server_fd;
+	pfd.events = POLLIN;
+	_poll_fds.push_back(pfd);
+}
+
+Server::~Server()
+{
+	close(_server_fd);
+}
+
+void	Server::run(void)
+{
+	std::cout << "Server is running..." << std::endl;
+	while (true)
+	{
+
+		int	ret = poll(&_poll_fds[0], _poll_fds.size(), -1);
+		if (ret < 0)
+		{
+			std::cerr << "poll: " << strerror(errno) << std::endl;
+			break;
+		}
+
+		
+		for (size_t i = 0; i < _poll_fds.size(); ++i)
+		{
+			if (_poll_fds[i].revents & POLLIN)
+			{
+				if (_poll_fds[i].fd == _server_fd)
+					acceptNewClient();
+				else
+					handleClientInput(_poll_fds[i].fd);
+			}
+		}
+	}
+	return ;
+}
+
+void	Server::exitError(std::string const & error_msg)
+{
+	std::cerr << error_msg << strerror(errno) << std::endl;
+	exit(1);
+}
+
+void	Server::acceptNewClient(void)
+{
+	int	client_fd = accept(_server_fd, NULL, NULL);
+	if (client_fd < 0)
+	{
+		std::cerr << "accept: " << strerror(errno) << std::endl;
+		return ;
+	}
+
+	struct pollfd pfd;
+	pfd.fd = client_fd;
+	pfd.events = POLLIN;
+	_poll_fds.push_back(pfd);
+	_client_buffers[client_fd] = "";
+	std::cout << "New client connected: " << client_fd << std::endl;
+	return ;
+}
+
+void	Server::handleClientInput(int fd)
+{
+	char	buf[BUF_SIZE];
+
+	int		n = recv(fd, buf, BUF_SIZE - 1, 0);
+	if (n <= 0)
+	{
+		removeClient(fd);
+		return ;
+	}
+
+	buf[n] = '\0';
+	_client_buffers[fd] += buf;
+
+	size_t pos;
+	while ((pos = _client_buffers[fd].find('\n')) != std::string::npos)
+	{
+		std::string msg = _client_buffers[fd].substr(0, pos + 1);
+		_client_buffers[fd].erase(0, pos + 1);
+		broadcast(fd, msg);
+	}
+	return ;
+}
+
+void	Server::broadcast(int sender_fd, std::string const & msg)
+{
+	for (size_t i = 1; i < _poll_fds.size(); ++i)
+	{
+		int fd = _poll_fds[i].fd;
+		if (fd != sender_fd)
+			send(fd, msg.c_str(), msg.size(), 0);
+	}
+	std::cout << "Broadcast from " << sender_fd << ": " << msg;
+	return ;
+}
+
+void	Server::removeClient(int fd)
+{
+	std::cout << "Client disconnected: " << fd << std::endl;
+	close(fd);
+
+	for (size_t i = 0; i < _poll_fds.size(); ++i)
+	{
+		if (_poll_fds[i]. fd == fd)
+		{
+			_poll_fds.erase(_poll_fds.begin() + i);
+			break ;
+		}
+	}
+	_client_buffers.erase(fd);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,24 @@
 
 #include <iostream> //cout
 
+#include "Server.hpp"
+
+int	main(int argc, char *argv[])
+{
+	if (argc != 3)
+	{
+		std::cerr << "Error: usage: ./ircserv [port] [password]" << std::endl;
+		return (1);
+	}
+
+	int			port = atoi(argv[1]);
+	std::string	password = argv[2];
+
+	Server	server(port);
+	server.run();
+	return (0);
+}
+
 
 /* server */
 // ```bash
@@ -27,107 +45,107 @@
 // /connect 127.0.0.1 6667
 // ```
 
-int	main() {
-	int	server_fd;
-	int	client_fd;
-	struct sockaddr_in	server_addr;
-	struct sockaddr_in	client_addr;
-	socklen_t	client_addr_len = sizeof(client_addr);
-	char	read_buffer[1024];
-	std::string	send_buffer;
-	int	port = 6667;
+// int	main() {
+// 	int	server_fd;
+// 	int	client_fd;
+// 	struct sockaddr_in	server_addr;
+// 	struct sockaddr_in	client_addr;
+// 	socklen_t	client_addr_len = sizeof(client_addr);
+// 	char	read_buffer[1024];
+// 	std::string	send_buffer;
+// 	int	port = 6667;
 
-	//ソケット生成
-	server_fd = socket(AF_INET, SOCK_STREAM, 0);
-	if (server_fd < 0) {
-		perror("socket error");
-		return (EXIT_FAILURE);
-	}
+// 	//ソケット生成
+// 	server_fd = socket(AF_INET, SOCK_STREAM, 0);
+// 	if (server_fd < 0) {
+// 		perror("socket error");
+// 		return (EXIT_FAILURE);
+// 	}
 
-	//サーバーアドレス構造体を設定
-	memset(&server_addr, 0, sizeof(server_addr));//ヌル埋め
-	server_addr.sin_family = AF_INET;//IPv4?
-	// server_addr.sin_addr.s_addr = htonl(INADDR_ANY);//htonlをなくすと仮想環境で接続ができなくなる。なぜ？
-	server_addr.sin_addr.s_addr = INADDR_ANY;
-	server_addr.sin_port = htons(port);//TCP/IP ネットワークのバイト順で値を返す
+// 	//サーバーアドレス構造体を設定
+// 	memset(&server_addr, 0, sizeof(server_addr));//ヌル埋め
+// 	server_addr.sin_family = AF_INET;//IPv4?
+// 	// server_addr.sin_addr.s_addr = htonl(INADDR_ANY);//htonlをなくすと仮想環境で接続ができなくなる。なぜ？
+// 	server_addr.sin_addr.s_addr = INADDR_ANY;
+// 	server_addr.sin_port = htons(port);//TCP/IP ネットワークのバイト順で値を返す
 
-	// ソケット登録
-	if (bind(server_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
-		perror("bind error");
-		close(server_fd);
-		return(EXIT_FAILURE);
-	}
+// 	// ソケット登録
+// 	if (bind(server_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+// 		perror("bind error");
+// 		close(server_fd);
+// 		return(EXIT_FAILURE);
+// 	}
 
-	//ソケット接続準備
-	if (listen(server_fd, 5) < 0) { //ここの5はマクロに変えてもいい?
-		perror("listen error");
-		close(server_fd);
-		return(EXIT_FAILURE);
-	}
-	std::cout << "Server listening on port " << port << ". /connect 127.0.0.1 6667" << std::endl;
+// 	//ソケット接続準備
+// 	if (listen(server_fd, 5) < 0) { //ここの5はマクロに変えてもいい?
+// 		perror("listen error");
+// 		close(server_fd);
+// 		return(EXIT_FAILURE);
+// 	}
+// 	std::cout << "Server listening on port " << port << ". /connect 127.0.0.1 6667" << std::endl;
 
-	//ソケット接続待機
-	client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &client_addr_len);
-	if (client_fd < 0) {
-		perror("accept error");
-		return (EXIT_FAILURE);
-	}
-	std::cout << "Client connected." << std::endl;
+// 	//ソケット接続待機
+// 	client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &client_addr_len);
+// 	if (client_fd < 0) {
+// 		perror("accept error");
+// 		return (EXIT_FAILURE);
+// 	}
+// 	std::cout << "Client connected." << std::endl;
 
-	//読み取り todo: 課題ではreadは使用してはいけないので修正が必要
-	while (true)
-	{
-		memset(&read_buffer, 0, sizeof(read_buffer));//ヌル埋め
-		//clientからのメッセージを読む
-		ssize_t	bytes_read = read(client_fd, read_buffer, sizeof(read_buffer) - 1);
-		if (bytes_read < 0) {
-			perror("read error");
-			close(client_fd);
-			close(server_fd);
-			return (EXIT_FAILURE);
-		}
-		read_buffer[bytes_read] = '\0';
-		// std::cout << "受信メッセージ: " << read_buffer << std::endl;
+// 	//読み取り todo: 課題ではreadは使用してはいけないので修正が必要
+// 	while (true)
+// 	{
+// 		memset(&read_buffer, 0, sizeof(read_buffer));//ヌル埋め
+// 		//clientからのメッセージを読む
+// 		ssize_t	bytes_read = read(client_fd, read_buffer, sizeof(read_buffer) - 1);
+// 		if (bytes_read < 0) {
+// 			perror("read error");
+// 			close(client_fd);
+// 			close(server_fd);
+// 			return (EXIT_FAILURE);
+// 		}
+// 		read_buffer[bytes_read] = '\0';
+// 		// std::cout << "受信メッセージ: " << read_buffer << std::endl;
 
-		if (strstr(read_buffer, "CAP LS") != NULL) {
-			std::cout << "CAP * LS :\r\n" << read_buffer << std::endl;
-			send_buffer = ":irc.example.com Hi! CAP!\r\n";
-		}
-		else if (strcmp(read_buffer, "NICK") == 0) {
-			std::cout << "受信メッセージ NICK: " << read_buffer << std::endl;
-			send_buffer = ":irc.example.com Hi! NICK!\r\n";
-		}
-		else if (strcmp(read_buffer, "USER") == 0) {
-			std::cout << "受信メッセージ USER: " << read_buffer << std::endl;
-			send_buffer = ":irc.example.com Hi! USER!\r\n";
-		}
-		else if (strcmp(read_buffer, "QUIT") == 0) {
-			std::cout << "受信メッセージ QUIT: " << read_buffer << std::endl;
-			break ;
-		}
-		else {
-			std::cout << "受信メッセージ: " << read_buffer << std::endl;
-			send_buffer = ":irc.example.com What???\r\n";
-		}
-		if (send(client_fd, send_buffer.c_str(), send_buffer.length(), 0) < 0) {
-			perror("send error");
-			close(client_fd);
-			close(server_fd);
-			return (EXIT_FAILURE);
-		}
-		// if (getline(std::cin, send_buffer)) {
-		// 	send_buffer += "\n";
-		// 	if (send(client_fd, send_buffer.c_str(), send_buffer.length(), 0) < 0) {
-		// 		perror("send error");
-		// 		close(client_fd);
-		// 		close(server_fd);
-		// 		return (EXIT_FAILURE);
-		// 	}
-		// }
-	}
+// 		if (strstr(read_buffer, "CAP LS") != NULL) {
+// 			std::cout << "CAP * LS :\r\n" << read_buffer << std::endl;
+// 			send_buffer = ":irc.example.com Hi! CAP!\r\n";
+// 		}
+// 		else if (strcmp(read_buffer, "NICK") == 0) {
+// 			std::cout << "受信メッセージ NICK: " << read_buffer << std::endl;
+// 			send_buffer = ":irc.example.com Hi! NICK!\r\n";
+// 		}
+// 		else if (strcmp(read_buffer, "USER") == 0) {
+// 			std::cout << "受信メッセージ USER: " << read_buffer << std::endl;
+// 			send_buffer = ":irc.example.com Hi! USER!\r\n";
+// 		}
+// 		else if (strcmp(read_buffer, "QUIT") == 0) {
+// 			std::cout << "受信メッセージ QUIT: " << read_buffer << std::endl;
+// 			break ;
+// 		}
+// 		else {
+// 			std::cout << "受信メッセージ: " << read_buffer << std::endl;
+// 			send_buffer = ":irc.example.com What???\r\n";
+// 		}
+// 		if (send(client_fd, send_buffer.c_str(), send_buffer.length(), 0) < 0) {
+// 			perror("send error");
+// 			close(client_fd);
+// 			close(server_fd);
+// 			return (EXIT_FAILURE);
+// 		}
+// 		// if (getline(std::cin, send_buffer)) {
+// 		// 	send_buffer += "\n";
+// 		// 	if (send(client_fd, send_buffer.c_str(), send_buffer.length(), 0) < 0) {
+// 		// 		perror("send error");
+// 		// 		close(client_fd);
+// 		// 		close(server_fd);
+// 		// 		return (EXIT_FAILURE);
+// 		// 	}
+// 		// }
+// 	}
 
-	// ソケット切断
-	close(client_fd);
-	close(server_fd);
-	return (EXIT_SUCCESS);
-}
+// 	// ソケット切断
+// 	close(client_fd);
+// 	close(server_fd);
+// 	return (EXIT_SUCCESS);
+// }


### PR DESCRIPTION
## 実装できてること
- サーバの起動・待機
    - `Server()`：サーバソケットを作成
    - `Server::run()`：`poll()`を使って、サーバとクライアントを監視（ノンブロッキング）
- 複数クライアントの同時接続・切断管理
    - `acceptNewClient()`：`accept()`で新しいクライアント接続を受付、`_poll_fds`に追加
    - `removeClient()`：`recv()`でクライアントからのデータ受信を試みたとき、戻り値が0または負値のとき切断処理を行う
- クライアントからのメッセージ受信
    - `handleClientInput()`：各クライアントから送られてきたデータを1行ごとに処理
    - `broadcast()`：受信したメッセージを他全クライアントに送信

## 主な動作確認
- サーバ起動
```
$ ./ircserv
```
- 複数の新しいターミナルからncコマンドでサーバに接続
```
$ nc localhost 6667
/* 任意の文字列を入力するとサーバ側、他の全クライアントに送信される */
```

## 次のステップ：1対1でクライアント同士のやりとり = `PRIVMSG`の実装
- クライアント識別の仕組み：ニックネームの設定（`NICK alice` → クライアントfdに「alice」を紐付け」）
- メッセージの宛先の指定：`PRIVMSG alice :hello!`コマンドを受け取ったら、「alice」にメッセージを送る
- コマンドパース処理：受信した文字列の処理（コマンド名、引数に分解）、コマンドごとに分岐
- クライアント管理の拡張：Databaseクラスの実装