### PR TITLE
feat: PRIVMSGコマンド登録と不具合修正

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -25,6 +25,8 @@
 #include "Command/UserCommand.hpp"
 #include "Command/PrivmsgCommand.hpp"
 
+#include "PrintLog.hpp"
+
 #define MAX_CLIENTS 10
 #define BUF_SIZE 512
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -19,10 +19,11 @@
 #include "Client.hpp"
 #include "Database.hpp"
 
-#include "Command/Command.hpp"
-#include "Command/PassCommand.hpp"
-#include "Command/NickCommand.hpp"
-#include "Command/UserCommand.hpp"
+#include "Command.hpp"
+#include "PassCommand.hpp"
+#include "NickCommand.hpp"
+#include "UserCommand.hpp"
+#include "PrivmsgCommand.hpp"
 
 #define MAX_CLIENTS 10
 #define BUF_SIZE 512

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -19,11 +19,11 @@
 #include "Client.hpp"
 #include "Database.hpp"
 
-#include "Command.hpp"
-#include "PassCommand.hpp"
-#include "NickCommand.hpp"
-#include "UserCommand.hpp"
-#include "PrivmsgCommand.hpp"
+#include "Command/Command.hpp"
+#include "Command/PassCommand.hpp"
+#include "Command/NickCommand.hpp"
+#include "Command/UserCommand.hpp"
+#include "Command/PrivmsgCommand.hpp"
 
 #define MAX_CLIENTS 10
 #define BUF_SIZE 512

--- a/src/Command/PrivmsgCommand.cpp
+++ b/src/Command/PrivmsgCommand.cpp
@@ -145,7 +145,7 @@ const t_response	PrivmsgCommand::execute(const t_parsed& input, Database& db) co
 
 	res.is_success = true;
 	res.should_send = true;
-	res.reply = input.args[1] + "\r\n";
+	res.reply = input.args[1];
 	std::cout << res.reply << std::endl;
 	res.target_fds = get_target_fd(input.args[0], db);
 

--- a/src/Command/PrivmsgCommand.cpp
+++ b/src/Command/PrivmsgCommand.cpp
@@ -121,11 +121,11 @@ static bool	is_validCmd(const t_parsed& input, t_response* res, Database& db) {
 		return(false);
 	}
 
-	if (is_channel(input.args[0]) && is_belong_channel(input, db)) //チャンネルに参加していない、もしくはBANされている時
+	if (is_channel(input.args[0]) && !is_belong_channel(input, db)) //チャンネルに参加していない、もしくはBANされている時
 	{
 		res->is_success = false;
 		res->should_send = true;
-		res->reply = ":ft.irc 474 " + input.args[0] + " :You are not in this channel.\r\n";
+		res->reply = ":ft.irc 442 " + input.args[0] + " :You are not in this channel.\r\n";
 		res->target_fds.resize(1);
 		res->target_fds[0] = input.client_fd;
 		return(false);
@@ -134,14 +134,19 @@ static bool	is_validCmd(const t_parsed& input, t_response* res, Database& db) {
 }
 
 const t_response	PrivmsgCommand::execute(const t_parsed& input, Database& db) const {
-	t_response	res;
+	t_response	res;	
+
+	res.is_success = false;
+	res.should_send = false;
+	res.should_disconnect = false;
 
 	if (!is_validCmd(input, &res, db))
 		return (res);
 
 	res.is_success = true;
 	res.should_send = true;
-	res.reply = input.args[1];
+	res.reply = input.args[1] + "\r\n";
+	std::cout << res.reply << std::endl;
 	res.target_fds = get_target_fd(input.args[0], db);
 
 	return (res);

--- a/src/Command/PrivmsgCommand.cpp
+++ b/src/Command/PrivmsgCommand.cpp
@@ -143,11 +143,22 @@ const t_response	PrivmsgCommand::execute(const t_parsed& input, Database& db) co
 	if (!is_validCmd(input, &res, db))
 		return (res);
 
+	Client * sender = db.getClient(input.client_fd);
+	std::string	nick = sender->getNickname();
+	std::string	user = sender->getUsername();
+	std::string	host = "ft.irc";
+
+	std::string	target = input.args[0];
+	std::string	text = input.args[1];
+
+	std::vector<int>	fds = get_target_fd(target, db);
+
+	std::string line =	":" + nick + "!" + user + "@" + host + " PRIVMSG " + target + " :" + text + "\r\n";
+
 	res.is_success = true;
 	res.should_send = true;
-	res.reply = input.args[1];
-	std::cout << res.reply << std::endl;
-	res.target_fds = get_target_fd(input.args[0], db);
+	res.reply = line;
+	res.target_fds = fds;
 
 	return (res);
 }

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -33,6 +33,19 @@ t_parsed Parser::exec(std::string line, int client_fd)
 	toUpperCase(parsed.cmd);
 	tokens.erase(tokens.begin());
 
+	if (trailing.empty() && parsed.cmd == "PRIVMSG" && tokens.size() >= 2)
+	{
+		std::string	joined;
+		for (size_t i = 1; i < tokens.size(); ++i)
+		{
+			if (i > 1)
+				joined += " ";
+			joined += tokens[i];
+		}
+		trailing = joined;
+		tokens.resize(1);
+	}
+
 	if (!trailing.empty())
 		tokens.push_back(trailing);
 
@@ -61,14 +74,28 @@ void	Parser::trimCRLF(std::string & s)
 
 void	Parser::extractTrailing(std::string & s, std::string & trailing)
 {
-	size_t	sep = s.find(" :");
-	if (sep != std::string::npos)
-	{
-		trailing = s.substr(sep + 2);
-		s.erase(sep);
-	}
+	// size_t	sep = s.find(" :");
+	// if (sep != std::string::npos)
+	// {
+	// 	trailing = s.substr(sep + 2);
+	// 	s.erase(sep);
+	// }
 
-	return ;
+	for (size_t i = 0; i < s.size(); ++i)
+	{
+		if (s[i] == ':')
+		{
+			if (i == 0)
+				continue ;
+			if (isspace(s[i - 1]))
+			{
+				trailing = s.substr(i + 1);
+				s.erase(i);
+				return ;
+			}
+		}
+	}
+	trailing.clear();
 }
 
 void	Parser::tokenize(std::string & s, std::vector<std::string> & tokens)

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -31,6 +31,7 @@ Server::Server(int port, std::string const & password)
 		_cmd_map["PASS"] = &PassCommand::createPassCommand;
 		_cmd_map["NICK"] = &NickCommand::createNickCommand;
 		_cmd_map["USER"] = &UserCommand::createUserCommand;
+		_cmd_map["PRIVMSG"] = &PrivmsgCommand::createPrivmsgCommand;
 	}
 }
 
@@ -206,7 +207,7 @@ void	Server::sendResponses(const t_response & res)
 	{
 		int fd = res.target_fds[i];
 		if (fd >= 0 && !res.reply.empty())
-		send(fd, res.reply.c_str(), res.reply.size(), 0);
+			send(fd, res.reply.c_str(), res.reply.size(), 0);
 	}
 
 	return ;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -123,15 +123,14 @@ void	Server::handleClientInput(int fd)
 		if (parsed.cmd.empty())
 			continue ;
 		
-		std::cout << "\n[RECV fd=" << parsed.client_fd << "] " << std::endl;
-		std::cout << msg << std::endl;
-		
-		std::cout << "COMMAND: " << std::endl;
-		std::cout << parsed.cmd << std::endl;
-		
-		std::cout << "ARGUMENTS: " << std::endl;
-		for (size_t i = 0; i < parsed.args.size(); i++)
-			std::cout << i << ": " << parsed.args[i] << std::endl;
+		PrintLog printlog;
+		printlog.print_debug("INPUT LINE: " + msg);
+		printlog.print_debug("COMMAND: " + parsed.cmd);
+		for (int i = 0; i < (int)parsed.args.size(); ++i)
+		{
+			std::cerr << "[" << i << "] ";
+			printlog.print_debug("ARGUMENT: " + parsed.args[i]);
+		}
 
 		if (!client->getIsRegistered())
 		{
@@ -166,7 +165,7 @@ void	Server::handleClientInput(int fd)
 			send(parsed.client_fd, unknown.c_str(), unknown.size(), 0);
 		}
 	}
-	std::cout << "\n \033[31m --- Receiving ends --- \033[m" << std::endl;
+	std::cout << "\033[31m --- Receiving ends --- \033[m" << std::endl;
 
 	return ;
 }
@@ -203,6 +202,8 @@ void	Server::sendResponses(const t_response & res)
 {
 	if (!res.should_send)
 		return ;
+	PrintLog printlog;
+	printlog.print_debug("SEND REPLY: " + res.reply);
 	for (size_t i = 0; i < res.target_fds.size(); ++i)
 	{
 		int fd = res.target_fds[i];

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: yohatana <yohatana@student.42.fr>          +#+  +:+       +#+         #
+#    By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/31 18:25:47 by miyuu             #+#    #+#              #
-#    Updated: 2025/08/25 17:36:52 by yohatana         ###   ########.fr        #
+#    Updated: 2025/09/02 18:55:49 by keishii          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -32,6 +32,7 @@ SRC					:= \
 					Server.cpp \
 					Parser.cpp \
 					Client.cpp \
+					Channel.cpp \
 					Database.cpp \
 					Command/Command.cpp \
 					Command/NickCommand.cpp \

--- a/test/test_cmd_privmsg.cpp
+++ b/test/test_cmd_privmsg.cpp
@@ -22,6 +22,7 @@ static void test_success() {
 
 		Client* c = db.addClient(fd);
 		c->setNickname("funa");
+		c->setUsername("funauser");
 
 		std::vector<std::string> args;
 		args.push_back("funa");
@@ -29,25 +30,39 @@ static void test_success() {
 
 		t_parsed in = makeInput("PRIVMSG", fd, args);
 		t_response res = privmsg.execute(in, db);
+
+		std::string expected = ":funa!funauser@ft.irc PRIVMSG funa :Send message successfully 1.\r\n";
+		// ":" + nick + "!" + user + "@" + host + " PRIVMSG " + target + " :" + text + "\r\n"
 		assert(res.is_success == true);
 		assert(res.should_send == true);
-		assert(res.reply == "Send message successfully 1.");
+		assert(res.reply == expected);
 		assert(res.target_fds.size() == 1 && res.target_fds[0] == fd);
 	}
-
+	
 	// 正常: 正しい		送信者と宛先が、異なるfd(違う人)の場合
 	{
-		int	fd = 5;
+		int	sender_fd = 5;
+		int	target_fd = 4;
+
+		Client *	target = db.addClient(target_fd);
+		target->setNickname("funa");
+		target->setUsername("funauser");
+
+		Client *	sender = db.addClient(sender_fd);
+		sender->setNickname("user1");
+		sender->setUsername("user1user");
 
 		std::vector<std::string> args;
 		args.push_back("funa");
 		args.push_back("Send message successfully 2.");
-
-		t_parsed in = makeInput("PRIVMSG", fd, args);
+		
+		t_parsed in = makeInput("PRIVMSG", sender_fd, args);
 		t_response res = privmsg.execute(in, db);
+
+		std::string expected = ":user1!user1user@ft.irc PRIVMSG funa :Send message successfully 2.\r\n";
 		assert(res.is_success == true);
 		assert(res.should_send == true);
-		assert(res.reply == "Send message successfully 2.");
+		assert(res.reply == expected);
 		assert(res.target_fds.size() == 1 && res.target_fds[0] == 4);
 	}
 }
@@ -59,6 +74,7 @@ static void test_factory() {
 
 	Client* c = db.addClient(fd);
 	c->setNickname("ken");
+	c->setUsername("kenuser");
 
 	std::vector<std::string> args;
 	args.push_back("ken");
@@ -66,9 +82,11 @@ static void test_factory() {
 
 	t_parsed in = makeInput("PRIVMSG", fd, args);
 	t_response res = cmd->execute(in, db);
+
+	std::string expected = ":ken!kenuser@ft.irc PRIVMSG ken :This is createPrivmsgCommand.\r\n";
 	assert(res.is_success == true);
 	assert(res.should_send == true);
-	assert(res.reply == "This is createPrivmsgCommand.");
+	assert(res.reply == expected);
 	assert(res.target_fds.size() == 1 && res.target_fds[0] == fd);
 }
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -100,7 +100,6 @@ int main()
 	// no msg
 	result = parser.exec("PRIVMSG B :\r\n", 4);
 	expect_v.push_back("B");
-	expect_v.push_back("");
 	assert(result.cmd == "PRIVMSG");
 	for(int i = 0; i < (int)expect_v.size();i++)
 		assert(result.args[i] == expect_v[i]);

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -74,8 +74,7 @@ int main()
 
 	result = parser.exec("PRIVMSG nick:42tokyo hello world\r\n", 4);
 	expect_v.push_back("nick:42tokyo");
-	expect_v.push_back("hello");
-	expect_v.push_back("world");
+	expect_v.push_back("hello world");
 	assert(result.cmd == "PRIVMSG");
 	for(int i = 0; i < (int)expect_v.size();i++)
 		assert(result.args[i] == expect_v[i]);
@@ -101,6 +100,7 @@ int main()
 	// no msg
 	result = parser.exec("PRIVMSG B :\r\n", 4);
 	expect_v.push_back("B");
+	expect_v.push_back("");
 	assert(result.cmd == "PRIVMSG");
 	for(int i = 0; i < (int)expect_v.size();i++)
 		assert(result.args[i] == expect_v[i]);


### PR DESCRIPTION
## 概要 <!-- 何をやりましたか？ -->
- `PRIVMSG` コマンドの実装（ニックネーム指定の個人宛て送信）を追加
- サーバ側のコマンド中継メッセージをRFC準拠の ‎`:<nick>!<user>@<host> PRIVMSG <target> :<text>\r\n` 形式に統一し、irssi・netcat両方で正しく動作するように変更
- 単体テスト・Parserテストの期待値も現状の仕様に合わせて修正

## 動作確認方法 <!-- どのように確認(テスト)すればいいですか？ -->
### netcatで手動テスト
- サーバ起動：
```
$ make
$ ./ircserv 6667 pass123
```
- 2つのターミナルで接続：
```
$ nc localhost 6667
pass pass123
nick user1
user user1 0 * :User One
```
```
$ nc localhost 6667
pass pass123
nick user2
user user2 0 * :User Two
```
- `user2` ターミナルで：
```
privmsg user1 :hello from user2
# user1 のターミナルでメッセージが表示される
```
### irssiでの動作確認
 • 2つのirssiクライアントで同様に接続し、/msgコマンドで相互にメッセージ送信
 • どちらのクライアントでも、正しくメッセージウィンドウが開き内容が表示されることを確認
![output-2 5x-15fps](https://github.com/user-attachments/assets/6ea452ca-f581-4a8b-b51a-72f30c1bc740)


## 補足 <!-- レビュワーに伝えたい追加情報や懸念点があれば記載してください -->

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [x] コンパイルできますか？
+ [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [x] セグフォ・リーク・free忘れはありませんか？
