### PR TITLE
PING / PONGコマンドの実装を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: yohatana <yohatana@student.42.fr>          +#+  +:+       +#+         #
+#    By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/31 18:25:47 by miyuu             #+#    #+#              #
-#    Updated: 2025/08/30 14:17:18 by yohatana         ###   ########.fr        #
+#    Updated: 2025/09/10 16:25:36 by keishii          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -38,6 +38,7 @@ SRC					:= \
 					Command/NickCommand.cpp \
 					Command/PassCommand.cpp \
 					Command/UserCommand.cpp \
+					Command/PongCommand.cpp \
 					PrintLog.cpp \
 					Command/PrivmsgCommand.cpp
 
@@ -52,6 +53,7 @@ HEADERS				:= \
 					Command/NickCommand.hpp \
 					Command/PassCommand.hpp \
 					Command/UserCommand.hpp \
+					Command/PongCommand.hpp \
 					PrintLog.hpp \
 					Command/PrivmsgCommand.hpp
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/31 18:25:47 by miyuu             #+#    #+#              #
-#    Updated: 2025/09/10 16:25:36 by keishii          ###   ########.fr        #
+#    Updated: 2025/09/12 21:00:25 by keishii          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -38,6 +38,7 @@ SRC					:= \
 					Command/NickCommand.cpp \
 					Command/PassCommand.cpp \
 					Command/UserCommand.cpp \
+					Command/PingCommand.cpp \
 					Command/PongCommand.cpp \
 					PrintLog.cpp \
 					Command/PrivmsgCommand.cpp
@@ -53,6 +54,7 @@ HEADERS				:= \
 					Command/NickCommand.hpp \
 					Command/PassCommand.hpp \
 					Command/UserCommand.hpp \
+					Command/PingCommand.hpp \
 					Command/PongCommand.hpp \
 					PrintLog.hpp \
 					Command/PrivmsgCommand.hpp

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -36,6 +36,9 @@ public:
 	bool				getUserReceived(void) const;
 	bool				getIsRegistered(void) const;
 	bool				getIsOperator(void) const;
+
+	time_t				getLastPingTime(void) const;
+	std::string			getLastPingToken(void) const;
 	
 	void				setNickname(const std::string& nickname);
 	void				setUsername(const std::string& username);
@@ -43,8 +46,11 @@ public:
 	void				setPassReceived(bool val);
 	void				setNickReceived(bool val);
 	void				setUserReceived(bool val);
-
+	
 	void				setIsRegistered(bool val);
+
+	void				setLastPingTime(time_t time);
+	void				setLastPingToken(std::string token);
 
 private:
 
@@ -62,6 +68,9 @@ private:
 
 	bool			_isRegistered;
 	bool			_isOperator;
+
+	time_t			_lastPingTime;
+	std::string		_lastPingToken;
 
 };
 

--- a/includes/Command/PingCommand.hpp
+++ b/includes/Command/PingCommand.hpp
@@ -25,7 +25,7 @@ public:
 
 private:
 
-	bool	isValidCmd(const t_parsed & input, t_response & res) const;
+	bool	isValidCmd(const t_parsed & input, t_response & res, Client & client) const;
 
 };
 

--- a/includes/Command/PingCommand.hpp
+++ b/includes/Command/PingCommand.hpp
@@ -1,0 +1,37 @@
+#ifndef PINGCOMMAND_HPP
+# define PINGCOMMAND_HPP
+
+// ------------------------------------------------
+// include
+// ------------------------------------------------
+
+#include <iostream>
+#include "Command.hpp"
+
+// ------------------------------------------------
+// class
+// ------------------------------------------------
+
+class PingCommand : public Command
+{
+
+public:
+
+	PingCommand();
+	~PingCommand();
+
+	static Command*			createPingCommand();
+	std::vector<t_response>	execute(const t_parsed & input, Database & db) const;
+
+private:
+
+	bool	isValidCmd(const t_parsed & input, t_response & res) const;
+
+};
+
+// ------------------------------------------------
+// function
+// ------------------------------------------------
+
+
+#endif

--- a/includes/Command/PongCommand.hpp
+++ b/includes/Command/PongCommand.hpp
@@ -1,0 +1,37 @@
+#ifndef PONGCOMMAND_HPP
+# define PONGCOMMAND_HPP
+
+// ------------------------------------------------
+// include
+// ------------------------------------------------
+
+#include <iostream>
+#include "Command.hpp"
+
+// ------------------------------------------------
+// class
+// ------------------------------------------------
+
+class PongCommand : public Command
+{
+
+public:
+
+	PongCommand();
+	~PongCommand();
+
+	static Command*					createPongCommand();
+	const std::vector<t_response>	execute(const t_parsed& input, Database& db) const;
+
+private:
+
+	bool	isValidCmd(const t_parsed & input, t_response & res, Client & client) const;
+
+};
+
+// ------------------------------------------------
+// function
+// ------------------------------------------------
+
+
+#endif

--- a/includes/Command/PongCommand.hpp
+++ b/includes/Command/PongCommand.hpp
@@ -20,8 +20,8 @@ public:
 	PongCommand();
 	~PongCommand();
 
-	static Command*					createPongCommand();
-	std::vector<t_response>	execute(const t_parsed& input, Database& db) const;
+	static Command*			createPongCommand();
+	std::vector<t_response>	execute(const t_parsed & input, Database & db) const;
 
 private:
 

--- a/includes/Command/PongCommand.hpp
+++ b/includes/Command/PongCommand.hpp
@@ -21,7 +21,7 @@ public:
 	~PongCommand();
 
 	static Command*					createPongCommand();
-	const std::vector<t_response>	execute(const t_parsed& input, Database& db) const;
+	std::vector<t_response>	execute(const t_parsed& input, Database& db) const;
 
 private:
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -13,6 +13,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/poll.h>
+#include <ctime>
 
 #include "Parser.hpp"
 
@@ -23,6 +24,7 @@
 #include "Command/PassCommand.hpp"
 #include "Command/NickCommand.hpp"
 #include "Command/UserCommand.hpp"
+#include "Command/PingCommand.hpp"
 #include "Command/PongCommand.hpp"
 #include "Command/PrivmsgCommand.hpp"
 
@@ -30,6 +32,8 @@
 
 #define MAX_CLIENTS 10
 #define BUF_SIZE 512
+#define TIMEOUT_MS 1000
+#define PING_INTERVAL 60
 
 class Server
 {
@@ -57,6 +61,10 @@ private:
 	typedef Command*				(*_cmdFunc)();
 	std::map<std::string, _cmdFunc>	_cmd_map;
 
+	time_t		_last_ping;
+	int			_ping_interval;
+	int			_timeout_ms;
+
 	void		acceptNewClient(void);
 	void		handleClientInput(int fd);
 	void		disconnectClient(int fd);
@@ -66,6 +74,9 @@ private:
 	void		sendResponses(const t_response & res);
 	bool		tryRegister(Client & client);
 	void		sendWelcome(Client & client);
+
+	void		sendPing(void);
+	void		checkClientTimeout(void);
 	
 	std::string	displayNick(const Client & client) const;
 	void		broadcast(int sender_fd, std::string const & msg);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -32,7 +32,7 @@
 
 #define MAX_CLIENTS 10
 #define BUF_SIZE 512
-#define TIMEOUT_MS 1000
+#define TIMEOUT_MS 0
 #define PING_INTERVAL 60
 
 class Server

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -23,6 +23,7 @@
 #include "Command/PassCommand.hpp"
 #include "Command/NickCommand.hpp"
 #include "Command/UserCommand.hpp"
+#include "Command/PongCommand.hpp"
 #include "Command/PrivmsgCommand.hpp"
 
 #include "PrintLog.hpp"

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -78,6 +78,16 @@ bool	Client::getIsRegistered() const {
 	return (_isRegistered);
 }
 
+time_t	Client::getLastPingTime(void) const
+{
+	return (_lastPingTime);
+}
+
+std::string	Client::getLastPingToken(void) const
+{
+	return (_lastPingToken);
+}
+
 void	Client::setUsername(const std::string & username)
 {
 	_username = username;
@@ -121,5 +131,17 @@ void	Client::setPassReceived(bool val)
 void	Client::setNickReceived(bool val)
 {
 	_nickReceived = val;
+	return ;
+}
+
+void	Client::setLastPingTime(time_t time)
+{
+	_lastPingTime = time;
+	return ;
+}
+
+void	Client::setLastPingToken(std::string token)
+{
+	_lastPingToken = token;
 	return ;
 }

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -4,7 +4,8 @@ Client::Client()
 :	_fd(0), _buffer(""),
 	_nickname(""), _username(""), _realname(""),
 	_passReceived(false), _nickReceived(false), _userReceived(false),
-	_isRegistered(false), _isOperator(false)
+	_isRegistered(false), _isOperator(false),
+	_lastPingTime(0), _lastPingToken("")
 {
 	_pfd.fd = 0;
 	_pfd.events = 0;

--- a/src/Command/PingCommand.cpp
+++ b/src/Command/PingCommand.cpp
@@ -1,0 +1,62 @@
+#include "Command/PingCommand.hpp"
+
+PingCommand::PingCommand() {}
+
+PingCommand::~PingCommand() {}
+
+Command *	PingCommand::createPingCommand() { return (new PingCommand()); }
+
+std::vector<t_response>	PingCommand::execute(const t_parsed & input, Database & db) const
+{
+	std::vector<t_response>	responses;
+	t_response				res;
+
+	res.is_success = false;
+	res.should_send = false;
+	res.should_disconnect = false;
+
+	
+	if(!isValidCmd(input, res))
+	{
+		responses.push_back(res);
+		return (responses);
+	}
+	Client *	sender_client = db.getClient(input.client_fd);
+	if (!sender_client)
+	{
+		responses.push_back(res);
+		return (responses);
+	}
+
+	sender_client->setLastPingTime(time(NULL));
+	std::string	token = input.args[0];
+	res.reply = "PONG :" + token + "\r\n";
+	res.target_fds.push_back(input.client_fd);
+	res.is_success = true;
+	res.should_send = true;
+
+	responses.push_back(res);
+	return (responses);
+}
+
+bool	PingCommand::isValidCmd(const t_parsed & input, t_response & res) const
+{
+	if (input.args.empty())
+	{
+		res.should_send = true;
+		res.reply = ":ft.irc 409 * :No origin specified\r\n";
+		res.target_fds.resize(1);
+		res.target_fds[0] = input.client_fd;
+		return (false);
+	}
+	// if (input.args.size() > 0 && input.args[0] != "ft.irc")
+	// {
+	// 	res.should_send = true;
+	// 	res.reply = ":ft.irc 402 " + client.getNickname() + " " + input.args[0] + " :No such server\r\n";
+	// 	res.target_fds.resize(1);
+	// 	res.target_fds[0] = input.client_fd;
+	// 	return (false);
+	// }
+
+	return (true);
+}

--- a/src/Command/PingCommand.cpp
+++ b/src/Command/PingCommand.cpp
@@ -15,14 +15,15 @@ std::vector<t_response>	PingCommand::execute(const t_parsed & input, Database & 
 	res.should_send = false;
 	res.should_disconnect = false;
 
-	
-	if(!isValidCmd(input, res))
+
+	Client *	sender_client = db.getClient(input.client_fd);
+	if (!sender_client)
 	{
 		responses.push_back(res);
 		return (responses);
 	}
-	Client *	sender_client = db.getClient(input.client_fd);
-	if (!sender_client)
+	
+	if(!isValidCmd(input, res, *sender_client))
 	{
 		responses.push_back(res);
 		return (responses);
@@ -39,24 +40,16 @@ std::vector<t_response>	PingCommand::execute(const t_parsed & input, Database & 
 	return (responses);
 }
 
-bool	PingCommand::isValidCmd(const t_parsed & input, t_response & res) const
+bool	PingCommand::isValidCmd(const t_parsed & input, t_response & res, Client & client) const
 {
 	if (input.args.empty())
 	{
 		res.should_send = true;
-		res.reply = ":ft.irc 409 * :No origin specified\r\n";
+		res.reply = ":ft.irc 409 " + client.getNickname() + " :No origin specified\r\n";
 		res.target_fds.resize(1);
 		res.target_fds[0] = input.client_fd;
 		return (false);
 	}
-	// if (input.args.size() > 0 && input.args[0] != "ft.irc")
-	// {
-	// 	res.should_send = true;
-	// 	res.reply = ":ft.irc 402 " + client.getNickname() + " " + input.args[0] + " :No such server\r\n";
-	// 	res.target_fds.resize(1);
-	// 	res.target_fds[0] = input.client_fd;
-	// 	return (false);
-	// }
 
 	return (true);
 }

--- a/src/Command/PongCommand.cpp
+++ b/src/Command/PongCommand.cpp
@@ -4,10 +4,7 @@ PongCommand::PongCommand() {}
 
 PongCommand::~PongCommand() {}
 
-Command *	PongCommand::createPongCommand()
-{
-	return (new PongCommand());
-}
+Command *	PongCommand::createPongCommand() { return (new PongCommand()); }
 
 std::vector<t_response>	PongCommand::execute(const t_parsed & input, Database & db) const
 {
@@ -17,7 +14,6 @@ std::vector<t_response>	PongCommand::execute(const t_parsed & input, Database & 
 	res.is_success = false;
 	res.should_send = false;
 	res.should_disconnect = false;
-	res.reply = "";
 
 	Client *	sender_client = db.getClient(input.client_fd);
 	if (!sender_client)
@@ -26,18 +22,14 @@ std::vector<t_response>	PongCommand::execute(const t_parsed & input, Database & 
 		return (responses);
 	}
 
-	if(!isValidCmd(input, res, *sender_client))
+	if (!isValidCmd(input, res, *sender_client))
 	{
 		responses.push_back(res);
 		return (responses);
 	}
 
+	sender_client->setLastPingTime(time(NULL));
 	res.is_success = true;
-	res.should_send = true;
-	std::string	token = input.args[0];
-	res.reply = "PONG :" + token + "\r\n";
-	res.target_fds.push_back(input.client_fd);
-
 	responses.push_back(res);
 	return (responses);
 }
@@ -48,18 +40,8 @@ bool	PongCommand::isValidCmd(const t_parsed & input, t_response & res, Client & 
 	{
 		res.should_send = true;
 		res.reply = ":ft.irc 409 " + client.getNickname() + " :No origin specified\r\n";
-		res.target_fds.resize(1);
-		res.target_fds[0] = input.client_fd;
+		res.target_fds.push_back(input.client_fd);
 		return (false);
 	}
-	if (input.args.size() > 0 && input.args[0] != "ft.irc")
-	{
-		res.should_send = true;
-		res.reply = ":ft.irc 402 " + client.getNickname() + " " + input.args[0] + " :No such server\r\n";
-		res.target_fds.resize(1);
-		res.target_fds[0] = input.client_fd;
-		return (false);
-	}
-
 	return (true);
 }

--- a/src/Command/PongCommand.cpp
+++ b/src/Command/PongCommand.cpp
@@ -1,4 +1,4 @@
-#include "PongCommand.hpp"
+#include "Command/PongCommand.hpp"
 
 PongCommand::PongCommand() {}
 

--- a/src/Command/PongCommand.cpp
+++ b/src/Command/PongCommand.cpp
@@ -1,0 +1,65 @@
+#include "PongCommand.hpp"
+
+PongCommand::PongCommand() {}
+
+PongCommand::~PongCommand() {}
+
+Command *	PongCommand::createPongCommand()
+{
+	return (new PongCommand());
+}
+
+const std::vector<t_response>	PongCommand::execute(const t_parsed & input, Database & db) const
+{
+	std::vector<t_response>	responses;
+	t_response				res;
+
+	res.is_success = false;
+	res.should_send = false;
+	res.should_disconnect = false;
+	res.reply = "";
+
+	Client *	sender_client = db.getClient(input.client_fd);
+	if (!sender_client)
+	{
+		responses.push_back(res);
+		return (responses);
+	}
+
+	if(!isValidCmd(input, res, *sender_client))
+	{
+		responses.push_back(res);
+		return (responses);
+	}
+
+	res.is_success = true;
+	res.should_send = true;
+	std::string	token = input.args[0];
+	res.reply = "PONG :" + token + "\r\n";
+	res.target_fds.push_back(input.client_fd);
+
+	responses.push_back(res);
+	return (responses);
+}
+
+bool	PongCommand::isValidCmd(const t_parsed & input, t_response & res, Client & client) const
+{
+	if (input.args.empty())
+	{
+		res.should_send = true;
+		res.reply = ":ft.irc 409 " + client.getNickname() + " :No origin specified\r\n";
+		res.target_fds.resize(1);
+		res.target_fds[0] = input.client_fd;
+		return (false);
+	}
+	if (input.args.size() > 0 && input.args[0] != "ft.irc")
+	{
+		res.should_send = true;
+		res.reply = ":ft.irc 402 " + client.getNickname() + " " + input.args[0] + " :No such server\r\n";
+		res.target_fds.resize(1);
+		res.target_fds[0] = input.client_fd;
+		return (false);
+	}
+
+	return (true);
+}

--- a/src/Command/PongCommand.cpp
+++ b/src/Command/PongCommand.cpp
@@ -9,7 +9,7 @@ Command *	PongCommand::createPongCommand()
 	return (new PongCommand());
 }
 
-const std::vector<t_response>	PongCommand::execute(const t_parsed & input, Database & db) const
+std::vector<t_response>	PongCommand::execute(const t_parsed & input, Database & db) const
 {
 	std::vector<t_response>	responses;
 	t_response				res;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -31,6 +31,7 @@ Server::Server(int port, std::string const & password)
 		_cmd_map["PASS"] = &PassCommand::createPassCommand;
 		_cmd_map["NICK"] = &NickCommand::createNickCommand;
 		_cmd_map["USER"] = &UserCommand::createUserCommand;
+		_cmd_map["PING"] = &PongCommand::createPongCommand;
 		_cmd_map["PRIVMSG"] = &PrivmsgCommand::createPrivmsgCommand;
 	}
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
+#    By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/31 18:25:47 by miyuu             #+#    #+#              #
-#    Updated: 2025/09/10 14:31:30 by miyuu            ###   ########.fr        #
+#    Updated: 2025/09/13 13:43:05 by keishii          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -38,6 +38,8 @@ SRC					:= \
 					Command/NickCommand.cpp \
 					Command/PassCommand.cpp \
 					Command/UserCommand.cpp \
+					Command/PingCommand.cpp \
+					Command/PongCommand.cpp \
 					Command/PrivmsgCommand.cpp \
 					PrintLog.cpp
 
@@ -52,6 +54,8 @@ HEADERS				:= \
 					NickCommand.hpp \
 					PassCommand.hpp \
 					UserCommand.hpp \
+					PingCommand.hpp \
+					PongCommand.hpp \
 					PrivmsgCommand.hpp \
 					PrintLog.hpp
 

--- a/test/test_cmd_ping.cpp
+++ b/test/test_cmd_ping.cpp
@@ -1,0 +1,94 @@
+#include <cassert>
+#include <string>
+#include <iostream>
+#include <cstring>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "../includes/Server.hpp"
+
+static int connect_client(int port)
+{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    assert(fd >= 0);
+    sockaddr_in addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    int r = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
+    assert(r == 0);
+    return fd;
+}
+
+static void send_line(int fd, const std::string& l)
+{
+    std::string msg = l;
+    if (msg.find("\r\n") == std::string::npos)
+        msg += "\r\n";
+    ssize_t n = send(fd, msg.c_str(), msg.size(), 0);
+    assert(n == (ssize_t)msg.size());
+}
+
+static std::string recv_nonblock(int fd)
+{
+    char buf[1024];
+    std::string out;
+    for (int i = 0; i < 10; ++i) {
+        ssize_t n = recv(fd, buf, sizeof(buf)-1, MSG_DONTWAIT);
+        if (n <= 0) break;
+        buf[n] = 0;
+        out += buf;
+    }
+    return out;
+}
+
+static void drive(Server& srv, int ms_total, int slice_ms=10)
+{
+    int elapsed = 0;
+    while (elapsed < ms_total) {
+        srv.step(slice_ms);
+        usleep(slice_ms * 1000);
+        elapsed += slice_ms;
+    }
+}
+
+static void test_ping_pong(Server& srv, int port)
+{
+    int fd = connect_client(port);
+
+    // 登録 (PASS/NICK/USER)
+    send_line(fd, "PASS pw");
+    send_line(fd, "NICK pinguser");
+    send_line(fd, "USER uu 0 * :Real User");
+    drive(srv, 200);
+    std::string r = recv_nonblock(fd);
+    assert(r.find(" 001 ") != std::string::npos); // 登録完了
+
+    // クライアント発 PING
+    std::string token = "abc123";
+    send_line(fd, "PING :" + token);
+    drive(srv, 100);
+    std::string r2 = recv_nonblock(fd);
+    // 期待: PONG :abc123
+    assert(r2.find("PONG :" + token) != std::string::npos);
+
+    // 引数なし PING → 409
+    send_line(fd, "PING");
+    drive(srv, 100);
+    std::string r3 = recv_nonblock(fd);
+    assert(r3.find(" 409 ") != std::string::npos);
+
+    close(fd);
+}
+
+int main()
+{
+    const int PORT = 7301; // 他テストと衝突しないポート
+    Server srv(PORT, "pw");
+    test_ping_pong(srv, PORT);
+    std::cout << "test_cmd_ping: OK\n";
+    return 0;
+}


### PR DESCRIPTION
## 概要 <!-- 何をやりましたか？ -->
- `PING`, `PONG` を実装
    - `PING` 受信時：引数が正常なら `PONG :<token>` を返信 + クライアントにタイムスタンプ（`_lastPingTime`）を残す
    - 引数なしの場合はエラー（`409`）
- `PONG` 受信時の反応
    - 正常なら送信クライアントの `lastPingTime` を更新（返信は行わない）
    - 引数なしの場合はエラー（`409`）
- サーバへの組み込み
    - クライアントごとに最終 `PING` 時刻と最後に送信したトークンを保持
    - 一定間隔（`_ping_interval`）ごとにサーバから `sendPing()` を行う
    - `checkClientTimeout()` によって、`2 * _ping_interval` の間クライアントが未応答の場合は切断

## 動作確認方法 <!-- どのように確認(テスト)すればいいですか？ -->
- 単体テスト `test/`
```
$ make re MAIN=test_cmd_ping.cpp
$ ./test_irc
```
- 手動確認→サーバを起動して、ncで接続
```
$ nc localhost <port>
pass <password>
nick nick
user user 0 * :real name
ping :hello
```
サーバから `PONG :hello` が返れば成功
60秒ごとに `PING` を受信する、2回連続で `PONG` で返信しなければ自動的に切断される

## 補足 <!-- レビュワーに伝えたい追加情報や懸念点があれば記載してください -->


### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [x] コンパイルできますか？
+ [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [x] セグフォ・リーク・free忘れはありませんか？
