### PR TITLE
JOINコマンドをサーバーに組み込み

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -27,6 +27,7 @@
 #include "Command/PingCommand.hpp"
 #include "Command/PongCommand.hpp"
 #include "Command/PrivmsgCommand.hpp"
+#include "Command/JoinCommand.hpp"
 
 #include "PrintLog.hpp"
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -35,6 +35,7 @@ _last_ping(time(NULL)), _ping_interval(PING_INTERVAL), _timeout_ms(TIMEOUT_MS)
 		_cmd_map["PING"] = &PingCommand::createPingCommand;
 		_cmd_map["PONG"] = &PongCommand::createPongCommand;
 		_cmd_map["PRIVMSG"] = &PrivmsgCommand::createPrivmsgCommand;
+		_cmd_map["JOIN"] = &JoinCommand::createJoinCommand;
 	}
 }
 


### PR DESCRIPTION
## 概要 <!-- 何をやりましたか？ -->
### JOINコマンドをサーバーに組み込み
- `JOIN` コマンドが処理（パース / バリデーション / DB更新 / レスポンス生成）されるようになった
    - チャンネル未存在時の生成と参加
    - 参加通知（フォーマット仮？）
    - `RPL_TOPIC（332）`と `RPL_NAMREPLY（353）`
    - 既存 / 新規メンバーへの `JOIN` ブロードキャスト
    - エラー応答：`461` / `403` / `476`

## 動作確認方法 <!-- どのように確認(テスト)すればいいですか？ -->


## 補足 <!-- レビュワーに伝えたい追加情報や懸念点があれば記載してください -->


### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [ ] コンパイルできますか？
+ [ ] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [ ] セグフォ・リーク・free忘れはありませんか？
