### PR TITLE
INVITEコマンドの実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
+#    By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/31 18:25:47 by miyuu             #+#    #+#              #
-#    Updated: 2025/09/15 13:52:57 by miyuu            ###   ########.fr        #
+#    Updated: 2025/09/16 15:11:55 by keishii          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -40,6 +40,7 @@ SRC					:= \
 					Command/UserCommand.cpp \
 					Command/PrivmsgCommand.cpp \
 					Command/JoinCommand.cpp \
+					Command/InviteCommand.cpp \
 					Command/PingCommand.cpp \
 					Command/PongCommand.cpp \
 					Utils.cpp \
@@ -58,6 +59,7 @@ HEADERS				:= \
 					Command/UserCommand.hpp \
 					Command/PrivmsgCommand.hpp \
 					Command/JoinCommand.hpp \
+					Command/InviteCommand.hpp \
 					Command/PingCommand.hpp \
 					Command/PongCommand.hpp \
 					Utils.hpp \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/31 18:25:47 by miyuu             #+#    #+#              #
-#    Updated: 2025/09/21 16:43:08 by keishii          ###   ########.fr        #
+#    Updated: 2025/09/21 18:39:30 by keishii          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -41,6 +41,7 @@ SRC					:= \
 					Command/UserCommand.cpp \
 					Command/PrivmsgCommand.cpp \
 					Command/JoinCommand.cpp \
+					Command/InviteCommand.cpp \
 					Command/PingCommand.cpp \
 					Command/PongCommand.cpp \
 					Utils.cpp \
@@ -60,6 +61,7 @@ HEADERS				:= \
 					Command/UserCommand.hpp \
 					Command/PrivmsgCommand.hpp \
 					Command/JoinCommand.hpp \
+					Command/InviteCommand.hpp \
 					Command/PingCommand.hpp \
 					Command/PongCommand.hpp \
 					Utils.hpp \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/31 18:25:47 by miyuu             #+#    #+#              #
-#    Updated: 2025/09/16 15:11:55 by keishii          ###   ########.fr        #
+#    Updated: 2025/09/16 15:49:09 by keishii          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -40,7 +40,6 @@ SRC					:= \
 					Command/UserCommand.cpp \
 					Command/PrivmsgCommand.cpp \
 					Command/JoinCommand.cpp \
-					Command/InviteCommand.cpp \
 					Command/PingCommand.cpp \
 					Command/PongCommand.cpp \
 					Utils.cpp \
@@ -59,7 +58,6 @@ HEADERS				:= \
 					Command/UserCommand.hpp \
 					Command/PrivmsgCommand.hpp \
 					Command/JoinCommand.hpp \
-					Command/InviteCommand.hpp \
 					Command/PingCommand.hpp \
 					Command/PongCommand.hpp \
 					Utils.hpp \

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -32,6 +32,7 @@ class Channel {
 		void	removeClientFd(int fd);
 
 		bool	isMember(int fd);
+		bool	isOperator(int fd);
 
 	private:
 		std::string				_name;

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -31,6 +31,8 @@ class Channel {
 		void	addClientFd(int fd);
 		void	removeClientFd(int fd);
 
+		bool	isMember(int fd);
+
 	private:
 		std::string				_name;
 		std::set<int>			_clientFds;

--- a/includes/Command/InviteCommand.hpp
+++ b/includes/Command/InviteCommand.hpp
@@ -1,0 +1,21 @@
+#ifndef INVITECOMMAND_HPP
+# define INVITECOMMAND_HPP
+
+#include "Command.hpp"
+
+class InviteCommand : public Command
+{
+
+public:
+
+	InviteCommand();
+	~InviteCommand();
+
+	static Command*			createInviteCommand();
+	std::vector<t_response>	execute(const t_parsed& input, Database& db) const;
+
+private:
+
+};
+
+#endif

--- a/includes/Command/InviteCommand.hpp
+++ b/includes/Command/InviteCommand.hpp
@@ -16,6 +16,10 @@ public:
 
 private:
 
+	bool		isValidCmd(const t_parsed & input, t_response & res, Database & db) const;
+	t_response	makeRplInviting(Client & inviter, Client & invitee, Channel & ch) const;
+	t_response	makeInviteLine(Client & inviter, Client & invitee, Channel & ch) const;
+
 };
 
 #endif

--- a/includes/Command/InviteCommand.hpp
+++ b/includes/Command/InviteCommand.hpp
@@ -17,8 +17,8 @@ public:
 private:
 
 	bool		isValidCmd(const t_parsed & input, t_response & res, Database & db) const;
-	t_response	makeRplInviting(Client & inviter, Client & invitee, Channel & ch) const;
-	t_response	makeInviteLine(Client & inviter, Client & invitee, Channel & ch) const;
+	t_response	makeRplInviting(Client & inviter, Client & invitee, const std::string chName) const;
+	t_response	makeInviteLine(Client & inviter, Client & invitee, const std::string chName) const;
 
 };
 

--- a/includes/Command/InviteCommand.hpp
+++ b/includes/Command/InviteCommand.hpp
@@ -17,8 +17,8 @@ public:
 private:
 
 	bool		isValidCmd(const t_parsed & input, t_response & res, Database & db) const;
-	t_response	makeRplInviting(Client & inviter, Client & invitee, const std::string chName) const;
-	t_response	makeInviteLine(Client & inviter, Client & invitee, const std::string chName) const;
+	t_response	makeRplInviting(Client & inviter, Client & invitee, const std::string & chName) const;
+	t_response	makeInviteLine(Client & inviter, Client & invitee, const std::string & chName) const;
 
 };
 

--- a/includes/Database.hpp
+++ b/includes/Database.hpp
@@ -31,6 +31,7 @@ public:
 	Client *			getClient(int fd);
 	Client const *		getClient(int fd) const;
 	Client *			getClient(std::string & nickname);
+	// Client const *		getClient(const std::string & nickname);
 	Channel const *		getChannel(const std::string& name) const;
 	Channel *			getChannel(const std::string& name);
 	const std::string&	getPassword() const;

--- a/includes/Database.hpp
+++ b/includes/Database.hpp
@@ -31,7 +31,7 @@ public:
 	Client *			getClient(int fd);
 	Client const *		getClient(int fd) const;
 	Client *			getClient(std::string & nickname);
-	// Client const *		getClient(const std::string & nickname);
+	Client const *		getClient(const std::string & nickname);
 	Channel const *		getChannel(const std::string& name) const;
 	Channel *			getChannel(const std::string& name);
 	const std::string&	getPassword() const;

--- a/includes/Database.hpp
+++ b/includes/Database.hpp
@@ -30,6 +30,7 @@ public:
 
 	Client *			getClient(int fd);
 	Client const *		getClient(int fd) const;
+	Client *			getClient(std::string & nickname);
 	Channel const *		getChannel(std::string & name) const;
 	Channel *			getChannel(std::string & name);
 	const std::string&	getPassword() const;

--- a/includes/Database.hpp
+++ b/includes/Database.hpp
@@ -30,6 +30,7 @@ public:
 
 	Client *			getClient(int fd);
 	Client const *		getClient(int fd) const;
+	Client *			getClient(std::string & nickname);
 	Channel const *		getChannel(const std::string& name) const;
 	Channel *			getChannel(const std::string& name);
 	const std::string&	getPassword() const;

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -65,3 +65,11 @@ bool	Channel::isMember(int fd)
 		return (false);
 	return (true);
 }
+
+bool	Channel::isOperator(int fd)
+{
+	std::set<int>::iterator	it = _channelOperatorFds.find(fd);
+	if (it == _channelOperatorFds.end())
+		return (false);
+	return (true);
+}

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -57,3 +57,11 @@ void	Channel::removeClientFd(int fd)
 	_channelOperatorFds.erase(fd);//todo: オペレーターが全員退出した場合の処理を考える。
 	_clientFds.erase(it);
 }
+
+bool	Channel::isMember(int fd)
+{
+	std::set<int>::iterator	it = _clientFds.find(fd);
+	if (it == _clientFds.end())
+		return (false);
+	return (true);
+}

--- a/src/Command/InviteCommand.cpp
+++ b/src/Command/InviteCommand.cpp
@@ -27,7 +27,7 @@ std::vector<t_response>	InviteCommand::execute(const t_parsed & input, Database 
 	std::string	chName = input.args[1];
 	Channel *	ch = db.getChannel(chName);
 
-	// ch->addClientFd(invitee->getFd());
+	ch->addInvite(invitee);
 
 	responses.push_back(makeRplInviting(*inviter, *invitee, *ch));
 	responses.push_back(makeInviteLine(*inviter, *invitee, *ch));

--- a/src/Command/InviteCommand.cpp
+++ b/src/Command/InviteCommand.cpp
@@ -1,0 +1,16 @@
+#include "Command/InviteCommand.hpp"
+
+InviteCommand::InviteCommand() {}
+
+InviteCommand::~InviteCommand() {}
+
+Command *	InviteCommand::createInviteCommand() { return (new InviteCommand()); }
+
+std::vector<t_response>	InviteCommand::execute(const t_parsed & input, Database & db) const
+{
+	std::vector<t_response>	responses;
+	t_response				res;
+
+	responses.push_back(res);
+	return (responses);
+}

--- a/src/Command/InviteCommand.cpp
+++ b/src/Command/InviteCommand.cpp
@@ -82,13 +82,13 @@ bool	InviteCommand::isValidCmd(const t_parsed & input, t_response & res, Databas
 						+ " :is already on channel\r\n";
 			return (false);
 		}
-		// if (/*チャンネルが招待制（Invite only） かつ inviterがオペレータではない*/)
-		// {
-		// 	res.reply = ":ft_irc 482 "
-		// 				+ inviter->getNickname() + input.args[1]
-		// 				+ "You're not channel operator\r\n";
-		// 	return (false);
-		// }
+		if (ch->isOperator(inviter->getFd()))
+		{
+			res.reply = ":ft_irc 482 "
+						+ inviter->getNickname() + input.args[1]
+						+ "You're not channel operator\r\n";
+			return (false);
+		}
 	}
 	else
 	{
@@ -112,7 +112,7 @@ t_response	InviteCommand::makeInviteLine(Client & inviter, Client & invitee, Cha
 {
 	t_response	res;
 
-	res.reply = ":" + inviter.getNickname() + "!" + inviter.getUsername() + "@" + "ft.irc"
+	res.reply = ":" + inviter.getNickname() + "!" + inviter.getUsername() + "@ft.irc"
 				+ " INVITE " + invitee.getNickname() + " :" + ch.getName() + "\r\n";
 	res.target_fds.push_back(invitee.getFd());
 	return (res);

--- a/src/Command/InviteCommand.cpp
+++ b/src/Command/InviteCommand.cpp
@@ -20,7 +20,7 @@ std::vector<t_response>	InviteCommand::execute(const t_parsed & input, Database 
 	}
 
 	Client *	inviter = db.getClient(input.client_fd);
-	const std::string	inviteeNick = input.args[0];
+	std::string	inviteeNick = input.args[0];
 	Client *	invitee = db.getClient(inviteeNick);
 	const std::string	chName = input.args[1];
 	Channel *	ch = db.getChannel(chName);
@@ -58,7 +58,7 @@ bool	InviteCommand::isValidCmd(const t_parsed & input, t_response & res, Databas
 		return (false);
 	}
 
-	const std::string	inviteeNick = input.args[0];
+	std::string	inviteeNick = input.args[0];
 	const std::string	chName = input.args[1];
 
 	Client *	invitee = db.getClient(inviteeNick);

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -37,6 +37,17 @@ Client const *	Database::getClient(int fd) const
 	return (&it->second);
 }
 
+Client *	Database::getClient(std::string & nickname)
+{
+	std::map<int, Client>::iterator	it = _clients.begin();
+	while (it->second.getNickname() != nickname)
+		++it;
+	if(it == _clients.end())
+		return (NULL);
+	else
+		return (&it->second);
+}
+
 const std::string&	Database::getPassword() const {
 	return (_password);
 }

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -48,6 +48,17 @@ Client *	Database::getClient(std::string & nickname)
 		return (&it->second);
 }
 
+// Client const *	Database::getClient(const std::string & nickname)
+// {
+// 	std::map<int, Client>::const_iterator it = _clients.begin();
+// 	while (it->second.getNickname() != nickname)
+// 		++it;
+// 	if (it == _clients.end())
+// 		return (NULL);
+// 	else
+// 		return (it->second);
+// }
+
 const std::string&	Database::getPassword() const {
 	return (_password);
 }

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -39,25 +39,23 @@ Client const *	Database::getClient(int fd) const
 
 Client *	Database::getClient(std::string & nickname)
 {
-	std::map<int, Client>::iterator	it = _clients.begin();
-	while (it->second.getNickname() != nickname)
-		++it;
-	if(it == _clients.end())
-		return (NULL);
-	else
-		return (&it->second);
+	for (std::map<int, Client>::iterator it = _clients.begin(); it != _clients.end(); ++it)
+	{
+		if (it->second.getNickname() == nickname)
+			return (&it->second);
+	}
+	return (NULL);
 }
 
-// Client const *	Database::getClient(const std::string & nickname)
-// {
-// 	std::map<int, Client>::const_iterator it = _clients.begin();
-// 	while (it->second.getNickname() != nickname)
-// 		++it;
-// 	if (it == _clients.end())
-// 		return (NULL);
-// 	else
-// 		return (it->second);
-// }
+Client const *	Database::getClient(const std::string & nickname)
+{
+	for (std::map<int, Client>::const_iterator it = _clients.begin(); it != _clients.end(); ++it)
+	{
+		if (it->second.getNickname() == nickname)
+			return (&it->second);
+	}
+	return (NULL);
+}
 
 const std::string&	Database::getPassword() const {
 	return (_password);

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
+#    By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/31 18:25:47 by miyuu             #+#    #+#              #
-#    Updated: 2025/09/20 19:16:26 by miyuu            ###   ########.fr        #
+#    Updated: 2025/09/21 18:43:02 by keishii          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -41,6 +41,7 @@ SRC					:= \
 					Command/UserCommand.cpp \
 					Command/PrivmsgCommand.cpp \
 					Command/JoinCommand.cpp \
+					Command/InviteCommand.cpp \
 					Command/PingCommand.cpp \
 					Command/PongCommand.cpp \
 					Utils.cpp \
@@ -60,6 +61,7 @@ HEADERS				:= \
 					UserCommand.hpp \
 					PrivmsgCommand.hpp \
 					JoinCommand.hpp \
+					InviteCommand.hpp \
 					PingCommand.hpp \
 					PongCommand.hpp \
 					Utils.hpp \

--- a/test/test_cmd_invite.cpp
+++ b/test/test_cmd_invite.cpp
@@ -1,0 +1,249 @@
+#include <cassert>
+#include <iostream>
+#include <algorithm>
+
+#include "Database.hpp"
+#include "Command/InviteCommand.hpp"
+
+static t_parsed makeInput(const std::string& cmd, int fd, const std::vector<std::string>& args) {
+    t_parsed in;
+    in.cmd = cmd;
+    in.client_fd = fd;
+    in.args = args;
+    return in;
+}
+
+static void test_success_existing_channel() {
+    Database db("password");
+    InviteCommand invite;
+
+    // inviter と invitee を準備
+    int inviter_fd = 1;
+    Client* inviter = db.addClient(inviter_fd);
+    inviter->setNickname("alice");
+
+    int invitee_fd = 2;
+    Client* invitee = db.addClient(invitee_fd);
+    invitee->setNickname("bob");
+
+    // 既存チャンネル作成（alice が OP）
+    Channel ch("#room", inviter_fd);
+    db.addChannel(ch);
+
+    std::vector<std::string> args;
+    args.push_back("bob");
+    args.push_back("#room");
+    t_parsed in = makeInput("INVITE", inviter_fd, args);
+    std::vector<t_response> res = invite.execute(in, db);
+
+    assert(res.size() == 2);
+
+    // 341 RPL_INVITING to inviter
+    assert(res[0].is_success == true);
+    assert(res[0].should_send == true);
+    assert(res[0].should_disconnect == false);
+    assert(res[0].reply.find(" 341 ") != std::string::npos);
+    assert(res[0].reply.find(" alice bob #room") != std::string::npos);
+    assert(res[0].target_fds.size() == 1 && res[0].target_fds[0] == inviter_fd);
+
+    // INVITE message to invitee
+    assert(res[1].is_success == true);
+    assert(res[1].should_send == true);
+    assert(res[1].should_disconnect == false);
+    assert(res[1].reply.find(" INVITE bob #room") != std::string::npos);
+    assert(res[1].target_fds.size() == 1 && res[1].target_fds[0] == invitee_fd);
+
+    // チャンネルの招待リストに invitee が追加されている
+    Channel* room = db.getChannel("#room");
+    assert(room != NULL);
+    assert(room->isInvited(invitee_fd) == true);
+}
+
+static void test_success_nonexistent_channel() {
+    Database db("password");
+    InviteCommand invite;
+
+    int inviter_fd = 10;
+    Client* inviter = db.addClient(inviter_fd);
+    inviter->setNickname("alice10");
+
+    int invitee_fd = 11;
+    Client* invitee = db.addClient(invitee_fd);
+    invitee->setNickname("bob11");
+
+    // チャンネルは存在しない
+    std::vector<std::string> args;
+    args.push_back("bob11");
+    args.push_back("#no_such");
+    t_parsed in = makeInput("INVITE", inviter_fd, args);
+    std::vector<t_response> res = invite.execute(in, db);
+
+    assert(res.size() == 2);
+    // 341 は返る
+    assert(res[0].reply.find(" 341 ") != std::string::npos);
+    assert(res[0].reply.find(" alice10 bob11 #no_such") != std::string::npos);
+    // INVITE も返る
+    assert(res[1].reply.find(" INVITE bob11 #no_such") != std::string::npos);
+
+    // チャンネルは作成されていない
+    assert(db.getChannel("#no_such") == NULL);
+}
+
+static void test_err_461_needmoreparams() {
+    Database db("password");
+    InviteCommand invite;
+
+    int fd = 20;
+    Client* c = db.addClient(fd);
+    c->setNickname("u20");
+
+    std::vector<std::string> args; // 引数なし
+    t_parsed in = makeInput("INVITE", fd, args);
+    std::vector<t_response> res = invite.execute(in, db);
+
+    assert(res.size() == 1);
+    assert(res[0].is_success == false);
+    assert(res[0].should_send == true);
+    assert(res[0].reply.find(" 461 ") != std::string::npos);
+    assert(res[0].target_fds.size() == 1 && res[0].target_fds[0] == fd);
+}
+
+static void test_err_401_nosuchnick() {
+    Database db("password");
+    InviteCommand invite;
+
+    int fd = 21;
+    Client* c = db.addClient(fd);
+    c->setNickname("u21");
+
+    std::vector<std::string> args;
+    args.push_back("nobody"); // 存在しないニック
+    args.push_back("#room");
+    t_parsed in = makeInput("INVITE", fd, args);
+    std::vector<t_response> res = invite.execute(in, db);
+
+    assert(res.size() == 1);
+    assert(res[0].is_success == false);
+    assert(res[0].should_send == true);
+    assert(res[0].reply.find(" 401 ") != std::string::npos);
+    assert(res[0].reply.find(" nobody ") != std::string::npos);
+    assert(res[0].target_fds.size() == 1 && res[0].target_fds[0] == fd);
+}
+
+static void test_err_442_notonchannel() {
+    Database db("password");
+    InviteCommand invite;
+
+    // inviter
+    int inviter_fd = 30;
+    Client* inviterCl = db.addClient(inviter_fd);
+    inviterCl->setNickname("inv30");
+
+    // invitee
+    int invitee_fd = 31;
+    Client* inviteeCl = db.addClient(invitee_fd);
+    inviteeCl->setNickname("bob31");
+
+    // inviter が参加していないチャンネルを作成（別ユーザが作成）
+    int owner_fd = 32;
+    Client* ownerCl = db.addClient(owner_fd);
+    ownerCl->setNickname("owner32");
+
+    Channel ch("#ch442", owner_fd);
+    db.addChannel(ch);
+
+    std::vector<std::string> args;
+    args.push_back("bob31");
+    args.push_back("#ch442");
+    t_parsed in = makeInput("INVITE", inviter_fd, args);
+    std::vector<t_response> res = invite.execute(in, db);
+
+    assert(res.size() == 1);
+    assert(res[0].is_success == false);
+    assert(res[0].should_send == true);
+    assert(res[0].reply.find(" 442 ") != std::string::npos);
+    assert(res[0].reply.find(" #ch442 ") != std::string::npos);
+    assert(res[0].target_fds.size() == 1 && res[0].target_fds[0] == inviter_fd);
+}
+
+static void test_err_482_notchanop() {
+    Database db("password");
+    InviteCommand invite;
+
+    // inviter（メンバーだがOPではない）
+    int inviter_fd = 40;
+    Client* inviterCl = db.addClient(inviter_fd);
+    inviterCl->setNickname("inv40");
+
+    // invitee
+    int invitee_fd = 41;
+    Client* inviteeCl = db.addClient(invitee_fd);
+    inviteeCl->setNickname("bob41");
+
+    // チャンネル作成（別ユーザがOP）
+    int owner_fd = 42;
+    Client* ownerCl = db.addClient(owner_fd);
+    ownerCl->setNickname("owner42");
+
+    Channel ch("#ch482", owner_fd);
+    // inviter をメンバーとして追加（OPにはしない）
+    ch.addClientFd(inviter_fd);
+    db.addChannel(ch);
+
+    std::vector<std::string> args;
+    args.push_back("bob41");
+    args.push_back("#ch482");
+    t_parsed in = makeInput("INVITE", inviter_fd, args);
+    std::vector<t_response> res = invite.execute(in, db);
+
+    assert(res.size() == 1);
+    assert(res[0].is_success == false);
+    assert(res[0].should_send == true);
+    assert(res[0].reply.find(" 482 ") != std::string::npos);
+    assert(res[0].reply.find(" #ch482 ") != std::string::npos);
+    assert(res[0].target_fds.size() == 1 && res[0].target_fds[0] == inviter_fd);
+}
+
+static void test_err_443_useronchannel() {
+    Database db("password");
+    InviteCommand invite;
+
+    // inviter（OP）
+    int inviter_fd = 50;
+    Client* inviterCl = db.addClient(inviter_fd);
+    inviterCl->setNickname("op50");
+
+    // invitee（既にメンバー）
+    int invitee_fd = 51;
+    Client* inviteeCl = db.addClient(invitee_fd);
+    inviteeCl->setNickname("bob51");
+
+    Channel ch("#ch443", inviter_fd); // inviter が OP
+    ch.addClientFd(invitee_fd);       // invitee はすでにメンバー
+    db.addChannel(ch);
+
+    std::vector<std::string> args;
+    args.push_back("bob51");
+    args.push_back("#ch443");
+    t_parsed in = makeInput("INVITE", inviter_fd, args);
+    std::vector<t_response> res = invite.execute(in, db);
+
+    assert(res.size() == 1);
+    assert(res[0].is_success == false);
+    assert(res[0].should_send == true);
+    assert(res[0].reply.find(" 443 ") != std::string::npos);
+    assert(res[0].reply.find(" bob51 #ch443 ") != std::string::npos);
+    assert(res[0].target_fds.size() == 1 && res[0].target_fds[0] == inviter_fd);
+}
+
+int main() {
+    test_success_existing_channel();
+    test_success_nonexistent_channel();
+    test_err_461_needmoreparams();
+    test_err_401_nosuchnick();
+    test_err_442_notonchannel();
+    test_err_482_notchanop();
+    test_err_443_useronchannel();
+    std::cout << "INVITE command tests: OK" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## 概要 <!-- 何をやりましたか？ -->
- `INVITE` コマンドの実装
    - チャンネルの有無に関わらず、入力のフォーマットが正しければ成功通知を返す
    - チャンネルが存在する場合、招待リストに `invitee` の `fd` を追加
- レスポンス
    - 成功：`341` を `inviter` へ、`INVITE` メッセージを `invitee` へ送信
    - エラー：`461` / `401` / `442` / `482` / `443` を返す

## 動作確認方法 <!-- どのように確認(テスト)すればいいですか？ -->
- 単体テスト：`test/test_cmd_invite.cpp` を追加
```
$ make test
```
`INVITE command tests: OK` が出ていればOK

## 補足 <!-- レビュワーに伝えたい追加情報や懸念点があれば記載してください -->


### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [x] コンパイルできますか？
+ [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [x] セグフォ・リーク・free忘れはありませんか？
