### PR TITLE
 kickコマンド実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+         #
+#    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/31 18:25:47 by miyuu             #+#    #+#              #
-#    Updated: 2025/09/23 18:21:23 by keishii          ###   ########.fr        #
+#    Updated: 2025/09/27 13:57:24 by miyuu            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -46,6 +46,7 @@ SRC					:= \
 					Command/PongCommand.cpp \
 					Command/TopicCommand.cpp \
 					Command/ModeCommand.cpp \
+					Command/KickCommand.cpp \
 					Utils.cpp \
 					PrintLog.cpp \
 
@@ -68,6 +69,7 @@ HEADERS				:= \
 					Command/PongCommand.hpp \
 					Command/TopicCommand.hpp \
 					Command/ModeCommand.hpp \
+					Command/KickCommand.hpp \
 					Utils.hpp \
 					PrintLog.hpp \
 

--- a/includes/Command/JoinCommand.hpp
+++ b/includes/Command/JoinCommand.hpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <vector>
 #include "Command.hpp"
+#include "Utils.hpp"
 
 struct s_join_item {
 	std::string	channel;

--- a/includes/Command/KickCommand.hpp
+++ b/includes/Command/KickCommand.hpp
@@ -1,13 +1,22 @@
 #ifndef KICKCOMMAND_HPP
 # define KICKCOMMAND_HPP
 
+// ------------------------------------------------
+// include
+// ------------------------------------------------
+
 #include "Command.hpp"
+#include "Utils.hpp"
 
 struct s_kick_item {
 	std::string	channel;
 	std::string	target;
 	std::string	comment;
 };
+
+// ------------------------------------------------
+// class
+// ------------------------------------------------
 
 class KickCommand : public Command
 {

--- a/includes/Command/KickCommand.hpp
+++ b/includes/Command/KickCommand.hpp
@@ -3,6 +3,12 @@
 
 #include "Command.hpp"
 
+struct s_kick_item {
+	std::string	channel;
+	std::string	target;
+	std::string	comment;
+};
+
 class KickCommand : public Command
 {
 
@@ -15,10 +21,12 @@ public:
 	std::vector<t_response>	execute(const t_parsed& input, Database& db) const;
 
 private:
-
-	bool		isValidCmd(const t_parsed & input, t_response & res, Database & db) const;
-	t_response	makeKickBroadcast(const Client& kicker, const std::string& chName, const Client& target, const std::string& comment, const std::set<int>& clientFds) const;
+	std::vector<s_kick_item>	parse_kick_args(const t_parsed& input) const;
+	bool		isValidParamsSize(const t_parsed& input, t_response& res, Database& db) const;
+	bool		isValidCmd(const t_parsed & input, t_response & res, Database & db, const std::string& chName, const std::string& targetNick) const;
+	t_response	executeKick(const t_parsed& input, Database& db, const s_kick_item& item) const;
+	void		updateDatabase(Database& db, const s_kick_item& item) const;
+	t_response	makeKickBroadcast(const t_parsed& input, Database& db, const s_kick_item& item) const;
 };
 
 #endif
-

--- a/includes/Command/KickCommand.hpp
+++ b/includes/Command/KickCommand.hpp
@@ -1,0 +1,24 @@
+#ifndef KICKCOMMAND_HPP
+# define KICKCOMMAND_HPP
+
+#include "Command.hpp"
+
+class KickCommand : public Command
+{
+
+public:
+
+	KickCommand();
+	~KickCommand();
+
+	static Command*			createKickCommand();
+	std::vector<t_response>	execute(const t_parsed& input, Database& db) const;
+
+private:
+
+	bool		isValidCmd(const t_parsed & input, t_response & res, Database & db) const;
+	t_response	makeKickBroadcast(const Client& kicker, const std::string& chName, const Client& target, const std::string& comment, const std::set<int>& clientFds) const;
+};
+
+#endif
+

--- a/includes/Database.hpp
+++ b/includes/Database.hpp
@@ -31,8 +31,8 @@ public:
 
 	Client *			getClient(int fd);
 	Client const *		getClient(int fd) const;
-	Client *			getClient(std::string & nickname);
-	Client const *		getClient(const std::string & nickname);
+	Client *			getClient(const std::string & nickname);
+	Client const *		getClient(const std::string & nickname) const;
 	Channel const *		getChannel(const std::string& name) const;
 	Channel *			getChannel(const std::string& name);
 	std::vector<std::string>	getAllChannelNames() const;

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -31,6 +31,7 @@
 #include "Command/JoinCommand.hpp"
 #include "Command/TopicCommand.hpp"
 #include "Command/ModeCommand.hpp"
+#include "Command/KickCommand.hpp"
 
 
 #include "PrintLog.hpp"

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -8,6 +8,9 @@
 #include <string>
 #include <cctype>
 #include <ctime>
+#include <cstdio>
+#include <sstream>
+#include <vector>
 
 // ------------------------------------------------
 // functions
@@ -15,5 +18,6 @@
 
 std::string toLowerCase(const std::string& input);
 std::string toString(time_t value);
+std::vector<std::string> split(const std::string& str, char delimiter);
 
 #endif

--- a/src/Command/JoinCommand.cpp
+++ b/src/Command/JoinCommand.cpp
@@ -8,17 +8,6 @@ Command*	JoinCommand::createJoinCommand() {
 	return (new JoinCommand());
 }
 
-static std::vector<std::string> split(const std::string& str, char delimiter) {
-	std::vector<std::string> tokens;
-	std::stringstream ss(str);
-	std::string token;
-
-	while (std::getline(ss, token, delimiter)) {
-		tokens.push_back(token);
-	}
-	return tokens;
-}
-
 std::vector<s_join_item> JoinCommand::parse_join_args(const t_parsed& input) const {
 	std::vector<s_join_item> res;
 	std::vector<std::string> channels;

--- a/src/Command/KickCommand.cpp
+++ b/src/Command/KickCommand.cpp
@@ -17,18 +17,6 @@ static void	set_err_res(t_response &res, const t_parsed& input, const std::strin
 	res.target_fds.push_back(input.client_fd);
 }
 
-static std::vector<std::string> split(const std::string& str, char delimiter)
-{
-	std::vector<std::string> tokens;
-	std::stringstream ss(str);
-	std::string token;
-	while (std::getline(ss, token, delimiter))
-	{
-		tokens.push_back(token);
-	}
-	return (tokens);
-}
-
 std::vector<s_kick_item>	KickCommand::parse_kick_args(const t_parsed& input) const
 {
 	std::vector<s_kick_item> items;

--- a/src/Command/KickCommand.cpp
+++ b/src/Command/KickCommand.cpp
@@ -75,7 +75,7 @@ bool	KickCommand::isValidCmd(const t_parsed & input, t_response & res, Database 
 		return (false);
 	}
 
-	Client *target = db.getClient(const_cast<std::string&>(targetNick));
+	Client *target = db.getClient(targetNick);
 	if (!target || !ch->isMember(target->getFd()))
 	{
 		set_err_res(res, input, "441 " + kicker->getNickname() + " " + targetNick + " " + chName + " :They aren't on that channel");
@@ -90,7 +90,7 @@ t_response	KickCommand::makeKickBroadcast(const t_parsed& input, Database& db, c
 	t_response res;
 	Client *kicker = db.getClient(input.client_fd);
 	Channel *ch = db.getChannel(item.channel);
-	Client *target = db.getClient(const_cast<std::string&>(item.target));
+	Client *target = db.getClient(item.target);
 	const std::set<int>& fds = ch->getClientFds();
 
 	res.is_success = true;
@@ -112,7 +112,7 @@ void	KickCommand::updateDatabase(Database& db, const s_kick_item& item) const
 	Channel *ch = db.getChannel(item.channel);
 	if (!ch)
 		return ;
-	Client *target = db.getClient(const_cast<std::string&>(item.target));
+	Client *target = db.getClient(item.target);
 	if (!target)
 		return ;
 	ch->removeClientFd(target->getFd());

--- a/src/Command/KickCommand.cpp
+++ b/src/Command/KickCommand.cpp
@@ -1,0 +1,107 @@
+#include "Command/KickCommand.hpp"
+
+KickCommand::KickCommand() {}
+
+KickCommand::~KickCommand() {}
+
+Command *	KickCommand::createKickCommand() { return (new KickCommand()); }
+
+static void	set_err_res(t_response &res, const t_parsed& input, const std::string& msg)
+{
+	res.is_success = false;
+	res.should_send = true;
+	res.should_disconnect = false;
+	res.reply = ":ft.irc " + msg + "\r\n";
+	res.target_fds.clear();
+	res.target_fds.push_back(input.client_fd);
+}
+
+bool	KickCommand::isValidCmd(const t_parsed & input, t_response & res, Database & db) const
+{
+	Client *kicker = db.getClient(input.client_fd);
+	if (!kicker)
+	{
+		res.should_send = false;
+		return (false);
+	}
+	if (input.args.size() < 2)
+	{
+		set_err_res(res, input, "461 " + kicker->getNickname() + " KICK :Not enough parameters");
+		return (false);
+	}
+
+	const std::string chName = input.args[0];
+	Channel *ch = db.getChannel(chName);
+	if (!ch)
+	{
+		set_err_res(res, input, "403 " + kicker->getNickname() + " " + chName + " :No such channel");
+		return (false);
+	}
+	if (!ch->isOperator(kicker->getFd()))
+	{
+		set_err_res(res, input, "482 " + kicker->getNickname() + " " + chName + " :You're not channel operator");
+		return (false);
+	}
+	if (!ch->isMember(kicker->getFd()))
+	{
+		set_err_res(res, input, "442 " + kicker->getNickname() + " " + chName + " :You're not on that channel");
+		return (false);
+	}
+
+	const std::string targetNick = input.args[1];
+	Client *target = db.getClient(const_cast<std::string&>(targetNick));
+	if (!target || !ch->isMember(target->getFd()))
+	{
+		set_err_res(res, input, "441 " + kicker->getNickname() + " " + targetNick + " " + chName + " :They aren't on that channel");
+		return (false);
+	}
+
+	res.is_success = true;
+	return (true);
+}
+
+t_response	KickCommand::makeKickBroadcast(const Client& kicker, const std::string& chName, const Client& target, const std::string& comment, const std::set<int>& clientFds) const
+{
+	t_response res;
+	res.is_success = true;
+	res.should_send = true;
+	res.should_disconnect = false;
+	std::string source = ":" + kicker.getNickname() + "!" + kicker.getUsername() + "@ft.irc";
+	std::string tail = comment.empty() ? "" : (" :" + comment);
+	res.reply = source + " KICK " + chName + " " + target.getNickname() + tail + "\r\n";
+	res.target_fds.assign(clientFds.begin(), clientFds.end());
+	return (res);
+}
+
+std::vector<t_response>	KickCommand::execute(const t_parsed& input, Database& db) const
+{
+	std::vector<t_response> responses;
+	t_response res;
+	res.is_success = false;
+	res.should_disconnect = false;
+	if (!isValidCmd(input, res, db))
+	{
+		responses.push_back(res);
+		return (responses);
+	}
+
+	Client *kicker = db.getClient(input.client_fd);
+	const std::string chName = input.args[0];
+	const std::string targetNick = input.args[1];
+	std::string comment;
+	if (input.args.size() >= 3) comment = input.args[2];
+
+	Channel *ch = db.getChannel(chName);
+	Client *target = db.getClient(const_cast<std::string&>(targetNick));
+	if (!kicker || !ch || !target)
+		return (responses);
+
+	// remove and broadcast
+	const std::set<int>& fds = ch->getClientFds();
+	responses.push_back(makeKickBroadcast(*kicker, chName, *target, comment, fds));
+	ch->removeClientFd(target->getFd());
+
+	return (responses);
+}
+
+

--- a/src/Command/KickCommand.cpp
+++ b/src/Command/KickCommand.cpp
@@ -64,14 +64,14 @@ bool	KickCommand::isValidCmd(const t_parsed & input, t_response & res, Database 
 		set_err_res(res, input, "403 " + kicker->getNickname() + " " + chName + " :No such channel");
 		return (false);
 	}
-	if (!ch->isOperator(kicker->getFd()))
-	{
-		set_err_res(res, input, "482 " + kicker->getNickname() + " " + chName + " :You're not channel operator");
-		return (false);
-	}
 	if (!ch->isMember(kicker->getFd()))
 	{
 		set_err_res(res, input, "442 " + kicker->getNickname() + " " + chName + " :You're not on that channel");
+		return (false);
+	}
+	if (!ch->isOperator(kicker->getFd()))
+	{
+		set_err_res(res, input, "482 " + kicker->getNickname() + " " + chName + " :You're not channel operator");
 		return (false);
 	}
 
@@ -99,7 +99,7 @@ t_response	KickCommand::makeKickBroadcast(const t_parsed& input, Database& db, c
 	std::string source = ":" + kicker->getNickname() + "!" + kicker->getUsername() + "@ft.irc";
 	std::string comment;
 	if (!item.comment.empty()) {
-		comment += ":";
+		comment += " :";
 		comment += item.comment;
 	}
 	res.reply = source + " KICK " + item.channel + " " + target->getNickname() + comment + "\r\n";

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -37,7 +37,7 @@ Client const *	Database::getClient(int fd) const
 	return (&it->second);
 }
 
-Client *	Database::getClient(std::string & nickname)
+Client *	Database::getClient(const std::string & nickname)
 {
 	for (std::map<int, Client>::iterator it = _clients.begin(); it != _clients.end(); ++it)
 	{
@@ -47,7 +47,7 @@ Client *	Database::getClient(std::string & nickname)
 	return (NULL);
 }
 
-Client const *	Database::getClient(const std::string & nickname)
+Client const *	Database::getClient(const std::string & nickname) const
 {
 	for (std::map<int, Client>::const_iterator it = _clients.begin(); it != _clients.end(); ++it)
 	{

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -39,6 +39,7 @@ _last_ping(time(NULL)), _ping_interval(PING_INTERVAL), _timeout_ms(TIMEOUT_MS)
 		_cmd_map["JOIN"] = &JoinCommand::createJoinCommand;
 		_cmd_map["TOPIC"] = &TopicCommand::createTopicCommand;
 		_cmd_map["MODE"] = &ModeCommand::createModeCommand;
+		_cmd_map["KICK"] = &KickCommand::createKickCommand;
 	}
 }
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,6 +1,4 @@
 #include "Utils.hpp"
-#include <cstdio>
-#include <sstream>
 
 std::string toLowerCase(const std::string& input)
 {
@@ -15,4 +13,15 @@ std::string toString(time_t value)
 	std::ostringstream oss;
 	oss << static_cast<unsigned long>(value);
 	return oss.str();
+}
+
+std::vector<std::string> split(const std::string& str, char delimiter) {
+	std::vector<std::string> tokens;
+	std::stringstream ss(str);
+	std::string token;
+
+	while (std::getline(ss, token, delimiter)) {
+		tokens.push_back(token);
+	}
+	return tokens;
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: keishii <keishii@student.42tokyo.jp>       +#+  +:+       +#+         #
+#    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/31 18:25:47 by miyuu             #+#    #+#              #
-#    Updated: 2025/09/23 20:01:06 by keishii          ###   ########.fr        #
+#    Updated: 2025/09/27 16:41:33 by miyuu            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -46,6 +46,7 @@ SRC					:= \
 					Command/PongCommand.cpp \
 					Command/TopicCommand.cpp \
 					Command/ModeCommand.cpp \
+					Command/KickCommand.cpp \
 					Utils.cpp \
 					PrintLog.cpp \
 
@@ -68,6 +69,7 @@ HEADERS				:= \
 					PongCommand.hpp \
 					TopicCommand.hpp \
 					ModeCommand.hpp \
+					KickCommand.hpp \
 					Utils.hpp \
 					PrintLog.hpp \
 

--- a/test/test_cmd_kick.cpp
+++ b/test/test_cmd_kick.cpp
@@ -1,0 +1,161 @@
+#include <cassert>
+#include <iostream>
+
+#include "Database.hpp"
+#include "Command/KickCommand.hpp"
+
+static t_parsed makeInput(const std::string& cmd, int fd, const std::vector<std::string>& args) {
+	t_parsed in;
+	in.cmd = cmd;
+	in.client_fd = fd;
+	in.args = args;
+	return in;
+}
+
+static void test_success_single_target() {
+	Database db("password");
+	KickCommand kick;
+
+	int op_fd = 1;
+	Client* op = db.addClient(op_fd);
+	op->setNickname("op1");
+	op->setUsername("u1");
+
+	int victim_fd = 2;
+	Client* victim = db.addClient(victim_fd);
+	victim->setNickname("vic2");
+	victim->setUsername("u2");
+
+	Channel ch("#room", op_fd);
+	ch.addClientFd(victim_fd);
+	db.addChannel(ch);
+
+	std::vector<std::string> args;
+	args.push_back("#room");
+	args.push_back("vic2");
+	args.push_back("bye");
+
+	std::vector<t_response> res = kick.execute(makeInput("KICK", op_fd, args), db);
+	assert(res.size() == 1);
+	assert(res[0].is_success == true);
+	assert(res[0].should_send == true);
+	assert(res[0].reply.find(" KICK #room vic2 :bye") != std::string::npos);
+
+	Channel* room = db.getChannel(std::string("#room"));
+	assert(room != NULL);
+	const std::set<int>& members = room->getClientFds();
+	assert(members.find(victim_fd) == members.end());
+}
+
+static void test_success_multi_targets() {
+	Database db("password");
+	KickCommand kick;
+
+	int op_fd = 10;
+	Client* op = db.addClient(op_fd);
+	op->setNickname("op10");
+	op->setUsername("u10");
+
+	int v1_fd = 11; db.addClient(v1_fd)->setNickname("v1");
+	int v2_fd = 12; db.addClient(v2_fd)->setNickname("v2");
+
+	Channel ch("#multi", op_fd);
+	ch.addClientFd(v1_fd);
+	ch.addClientFd(v2_fd);
+	db.addChannel(ch);
+
+	std::vector<std::string> args;
+	args.push_back("#multi");
+	args.push_back("v1,v2");
+
+	std::vector<t_response> res = kick.execute(makeInput("KICK", op_fd, args), db);
+	assert(res.size() == 2);
+	assert(res[0].reply.find(" KICK #multi v1") != std::string::npos);
+	assert(res[1].reply.find(" KICK #multi v2") != std::string::npos);
+
+	Channel* room = db.getChannel(std::string("#multi"));
+	assert(room != NULL);
+	const std::set<int>& members = room->getClientFds();
+	assert(members.find(v1_fd) == members.end());
+	assert(members.find(v2_fd) == members.end());
+}
+
+static void test_err_461_needmoreparams() {
+	Database db("password");
+	KickCommand kick;
+	int fd = 20;
+	db.addClient(fd)->setNickname("u20");
+
+	std::vector<std::string> args; // 引数なし
+	std::vector<t_response> res = kick.execute(makeInput("KICK", fd, args), db);
+	assert(res.size() == 1);
+	assert(res[0].is_success == false);
+	assert(res[0].should_send == true);
+	assert(res[0].reply.find(" 461 ") != std::string::npos);
+}
+
+static void test_err_403_482_442_441() {
+	Database db("password");
+	KickCommand kick;
+
+	int fd = 30;
+	Client* user = db.addClient(fd);
+	user->setNickname("u30");
+	user->setUsername("uu");
+
+	// 403: チャンネルなし
+	{
+		std::vector<std::string> args;
+		args.push_back("#nope");
+		args.push_back("someone");
+		std::vector<t_response> res = kick.execute(makeInput("KICK", fd, args), db);
+		assert(res.size() == 1);
+		assert(res[0].reply.find(" 403 u30 #nope ") != std::string::npos);
+	}
+
+	// チャンネルを作成（fdがOP）だが被キック者は不在 → 441
+	Channel ch("#x", fd);
+	db.addChannel(ch);
+	{
+		std::vector<std::string> args;
+		args.push_back("#x");
+		args.push_back("ghost");
+		std::vector<t_response> res = kick.execute(makeInput("KICK", fd, args), db);
+		assert(res.size() == 1);
+		assert(res[0].reply.find(" 441 u30 ghost #x ") != std::string::npos);
+	}
+
+	// チャンネルメンバーでないユーザーが実行→ 442
+	int outsider_fd = 32;
+	db.addClient(outsider_fd)->setNickname("u32");
+	{
+		std::vector<std::string> args;
+		args.push_back("#x");
+		args.push_back("u30");
+		std::vector<t_response> res = kick.execute(makeInput("KICK", outsider_fd, args), db);
+		assert(res.size() == 1);
+		assert(res[0].reply.find(" 442 u32 #x ") != std::string::npos);
+	}
+
+	// OPでないユーザが実行 → 482
+	int notop_fd = 31; db.addClient(notop_fd)->setNickname("u31");
+	db.getChannel(std::string("#x"))->addClientFd(notop_fd);
+	{
+		std::vector<std::string> args;
+		args.push_back("#x");
+		args.push_back("u30");
+		std::vector<t_response> res = kick.execute(makeInput("KICK", notop_fd, args), db);
+		assert(res.size() == 1);
+		assert(res[0].reply.find(" 482 u31 #x ") != std::string::npos);
+	}
+
+}
+
+int main() {
+	test_success_single_target();
+	test_success_multi_targets();
+	test_err_461_needmoreparams();
+	test_err_403_482_442_441();
+	std::cout << "KICK command tests: OK" << std::endl;
+	return 0;
+}

--- a/test/test_cmd_topic.cpp
+++ b/test/test_cmd_topic.cpp
@@ -1,8 +1,6 @@
 #include <cassert>
 #include <iostream>
 #include <algorithm>
-#include <cstdlib>
-#include <ctime>
 
 #include "Database.hpp"
 #include "Command/TopicCommand.hpp"


### PR DESCRIPTION
## 概要 <!-- 何をやりましたか？ -->
[KICKコマンドに関して](https://github.com/funa-yuy/42_irc/issues/62)
- Kickコマンドの実装
     - 構文`KICK <channel> <client> <comment>`
       カンマ区切りで複数のクライアントを指定できる。
例) `KICK channel user1,user2`
- 処理の流れ
1. 引数の数が足りているかのチェック
2. パースして`s_kick_item`構造体に格納
3. 1つずつ実行
       - エラーの場合: 461/ 403/482/441/442を返す
       - 正常な場合: `makeKickBroadcast`関数に行く
- `server.cpp`への組み込み


## 動作確認方法 <!-- どのように確認(テスト)すればいいですか？ -->
```bash
cd test
make re MAIN=test_cmd_kick.cpp
./test_irc 
```

## 補足 <!-- レビュワーに伝えたい追加情報や懸念点があれば記載してください -->


### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [ ] コンパイルできますか？
+ [ ] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [ ] セグフォ・リーク・free忘れはありませんか？
