### PR TITLE
🏥 チャンネルに2回privmsgが送られるの直しt

### DIFF
--- a/src/Command/PrivmsgCommand.cpp
+++ b/src/Command/PrivmsgCommand.cpp
@@ -61,13 +61,10 @@ std::vector<int> PrivmsgCommand::get_fd_ByChannel(std::string	target, Database& 
 
 bool PrivmsgCommand::is_belong_channel(const t_parsed& input, Database& db) const
 {
-	std::vector<int> fds =  get_fd_ByChannel(input.args[0], db);
-	for (int i = 0; i < (int)fds.size();i++)
-	{
-		if (fds[i] == input.client_fd)
-			return (true);
-	}
-	return (false);
+	Channel * ch = db.getChannel(input.args[0]);
+	if (!ch)
+		return (false);
+	return ch->isMember(input.client_fd);
 }
 
 std::vector<int>	PrivmsgCommand::get_target_fd(std::string target, Database& db) const{

--- a/test/test_cmd_privmsg.cpp
+++ b/test/test_cmd_privmsg.cpp
@@ -34,7 +34,6 @@ static void test_success() {
 		const t_response & res = response_list[0];
 
 		std::string expected = ":funa!funauser@ft.irc PRIVMSG funa :Send message successfully 1.\r\n";
-		// ":" + nick + "!" + user + "@" + host + " PRIVMSG " + target + " :" + text + "\r\n"
 		assert(res.is_success == true);
 		assert(res.should_send == true);
 		assert(res.reply == expected);
@@ -222,8 +221,7 @@ static void test_channel_broadcast()
 	assert(result[0].reply == ":client1!@ft.irc PRIVMSG #test1 :only one\r\n");
 	assert(result[0].should_disconnect == false);
 	assert(result[0].should_send == true);
-	assert(result[0].target_fds.size() == 1);
-	assert(result[0].target_fds[0] == parse.client_fd);
+	assert(result[0].target_fds.size() == 0);
 	result.clear();
 	parse.args.clear();
 
@@ -241,9 +239,8 @@ static void test_channel_broadcast()
 	assert(result[0].reply == ":client1!@ft.irc PRIVMSG #test2 :member 2\r\n");
 	assert(result[0].should_disconnect == false);
 	assert(result[0].should_send == true);
-	assert(result[0].target_fds.size() == 2);
-	assert(result[0].target_fds[0] == parse.client_fd);
-	assert(result[0].target_fds[1] == 4);
+	assert(result[0].target_fds.size() == 1);
+	assert(result[0].target_fds[0] == 4);
 	result.clear();
 	parse.args.clear();
 
@@ -261,10 +258,9 @@ static void test_channel_broadcast()
 	assert(result[0].reply == ":client1!@ft.irc PRIVMSG #test3 :member 3 full!\r\n");
 	assert(result[0].should_disconnect == false);
 	assert(result[0].should_send == true);
-	assert(result[0].target_fds.size() == 3);
-	assert(result[0].target_fds[0] == parse.client_fd);
-	assert(result[0].target_fds[1] == 4);
-	assert(result[0].target_fds[2] == 5);
+	assert(result[0].target_fds.size() == 2);
+	assert(result[0].target_fds[0] == 4);
+	assert(result[0].target_fds[1] == 5);
 	result.clear();
 	parse.args.clear();
 
@@ -299,7 +295,6 @@ static void test_channel_broadcast()
 
 	assert(result.size() == 1);
 	assert(result[0].is_success == false);
-	// :ft.irc 401 :No such nick/channel\r\nではない？
 	assert(result[0].reply == ":ft.irc 401 noexist :No such nick/channel\r\n");
 	assert(result[0].should_disconnect == false);
 	assert(result[0].should_send == true);


### PR DESCRIPTION
## 概要 <!-- 何をやりましたか？ -->
- チャンネルに対してprivmsgコマンドを実行した際、2回メッセージが表示されるバクを修正
   → チャンネルに送る際、送信先fdの中から自分のfdを除くようにした
- 上記に伴い、単体テストの修正
- 軽くリファクタリング

## 動作確認方法 <!-- どのように確認(テスト)すればいいですか？ -->
```bash
cd test
make re MAIN=test_cmd_privmsg.cpp
./test_irc
```

## 補足 <!-- レビュワーに伝えたい追加情報や懸念点があれば記載してください -->
- 自分に対してprivmsgコマンドを送る場合、2回表示されるのは正しい挙動なので、そこの修正はしてないです

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [ ] コンパイルできますか？
+ [ ] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [ ] セグフォ・リーク・free忘れはありませんか？
