### PR TITLE
🛠️ 引数の上限と文字数の上限を追加した

### DIFF
--- a/includes/Parser.hpp
+++ b/includes/Parser.hpp
@@ -1,13 +1,14 @@
 #ifndef PARSER_HPP
- #define PARSER_HPP
+#define PARSER_HPP
 
- #include <string>
- #include <iostream>
- #include <sstream>
- #include <vector>
- #include "irc.hpp"
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include "irc.hpp"
 
- #define MAX_MSG_ARG 15
+#define MAX_MSG_ARG 15
+#define MAX_LINE_NOCRLF 510
 
 class Parser
 {

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -8,6 +8,10 @@ t_parsed Parser::exec(std::string line, int client_fd)
 	// 末尾の CR/LF を除去
 	trimCRLF(line);
 
+	// 512バイト上限（CRLF込み）: 本体は最大510文字に制限
+	if (line.size() > MAX_LINE_NOCRLF)
+		line.erase(MAX_LINE_NOCRLF);
+
 	// 入力行が空白のみの場合、早期リターン
 	if (line.find_first_not_of(" \t") == std::string::npos)
 	{
@@ -49,9 +53,9 @@ t_parsed Parser::exec(std::string line, int client_fd)
 	if (!trailing.empty())
 		tokens.push_back(trailing);
 
-	// 引数上限チェック
+	// 引数上限チェック（最大15個に切り捨て）
 	if (tokens.size() > MAX_MSG_ARG)
-		std::cerr << "too many args" << std::endl;
+		tokens.resize(MAX_MSG_ARG);
 
 	parsed.args = tokens;
 
@@ -112,7 +116,7 @@ void	Parser::tokenize(std::string & s, std::vector<std::string> & tokens)
 void	Parser::toUpperCase(std::string & s)
 {
 	for (size_t i = 0; i < s.size(); ++i)
-		s[i] = std::toupper(s[i]);	
+		s[i] = std::toupper(s[i]);
 
 	return ;
 }


### PR DESCRIPTION
## 概要 <!-- 何をやりましたか？ -->
- 引数を上限を15に設定。15個目以降は切り捨てる
- 文字数の上限を510バイト(\r\n含まない)に設定。510バイト以降は切り捨てる。
- 上記の単体テストを追加

## 動作確認方法 <!-- どのように確認(テスト)すればいいですか？ -->
```bash
cd test
make re MAIN=test_parser.cpp
./test_irc 
```

## 補足 <!-- レビュワーに伝えたい追加情報や懸念点があれば記載してください -->


### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [x] コンパイルできますか？
+ [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [x] セグフォ・リーク・free忘れはありませんか？
