### PR TITLE
🛠️ パスワードが間違っていても切断しないようにした

### DIFF
--- a/src/Command/PassCommand.cpp
+++ b/src/Command/PassCommand.cpp
@@ -33,7 +33,6 @@ bool	is_validCmd(const t_parsed& input, t_response* res, Database& db) {
 	{
 		res->is_success = false;
 		res->should_send = true;
-		res->should_disconnect = true;
 		res->reply = ":ft.irc 464 " + sender_client->getNickname() + " PASS :Password incorrect\r\n";
 		res->target_fds.resize(1);
 		res->target_fds[0] = input.client_fd;

--- a/test/test_cmd_pass.cpp
+++ b/test/test_cmd_pass.cpp
@@ -25,6 +25,7 @@ static void test_pass_command_all() {
 		const t_response & res = response_list[0];
 		assert(res.is_success == false);
 		assert(res.should_send == true);
+		assert(res.should_disconnect == false);
 		assert(res.reply.find("461") != std::string::npos);
 		assert(res.target_fds.size() == 1 && res.target_fds[0] == fd);
 	}
@@ -40,6 +41,7 @@ static void test_pass_command_all() {
 		const t_response & res = response_list[0];
 		assert(res.is_success == false);
 		assert(res.should_send == true);
+		assert(res.should_disconnect == false);
 		assert(res.reply.find("462") != std::string::npos);
 		assert(res.target_fds.size() == 1 && res.target_fds[0] == fd);
 	}
@@ -54,6 +56,7 @@ static void test_pass_command_all() {
 		const t_response & res = response_list[0];
 		assert(res.is_success == false);
 		assert(res.should_send == true);
+		assert(res.should_disconnect == false);
 		assert(res.reply.find("464") != std::string::npos);
 		assert(res.target_fds.size() == 1 && res.target_fds[0] == fd);
 	}


### PR DESCRIPTION
## 概要 <!-- 何をやりましたか？ -->
- PASSコマンドにおいて、パスワードが間違っていてもクライアントを切断しないようにした
- `test_cmd_pass.cpp`と`test_server.cpp`の修正
## 動作確認方法 <!-- どのように確認(テスト)すればいいですか？ -->
```bash
cd test
make re MAIN= test_cmd_pass.cpp
./test_irc

make re MAIN= test_server.cpp
./test_irc
```

## 補足 <!-- レビュワーに伝えたい追加情報や懸念点があれば記載してください -->


### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [ ] コンパイルできますか？
+ [ ] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [ ] セグフォ・リーク・free忘れはありませんか？
