### PR TITLE
103-ノンブロッキング対応

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -14,6 +14,7 @@
 #include <sys/socket.h>
 #include <sys/poll.h>
 #include <ctime>
+#include <fcntl.h>
 
 #include "Parser.hpp"
 
@@ -79,6 +80,7 @@ private:
 	Command *	createCommandObj(std::string cmd_name);
 
 	void		sendResponses(const t_response & res);
+	bool		sendAllNonBlocking(int fd, const char * data, size_t len);
 	bool		tryRegister(Client & client);
 	void		sendWelcome(Client & client);
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -15,6 +15,7 @@
 #include <sys/poll.h>
 #include <ctime>
 #include <fcntl.h>
+#include <signal.h>
 
 #include "Parser.hpp"
 
@@ -40,7 +41,7 @@
 
 #define MAX_CLIENTS 10
 #define BUF_SIZE 512
-#define TIMEOUT_MS 0
+#define TIMEOUT_MS 50
 #define PING_INTERVAL 180
 
 class Server
@@ -74,7 +75,12 @@ private:
 	int			_timeout_ms;
 
 	void		acceptNewClient(void);
+
 	void		handleClientInput(int fd);
+	bool		readFromSocket(int fd, std::string & buffer, bool & closed, bool & fatalError);
+	void		extractClientBufferLine(int fd, std::string & buffer);
+	bool		executeCmdLine(int fd, const std::string & msg);
+
 	void		disconnectClient(int fd);
 
 	Command *	createCommandObj(std::string cmd_name);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -40,7 +40,9 @@
 #include "PrintLog.hpp"
 
 #define MAX_CLIENTS 10
-#define BUF_SIZE 512
+#define BUF_SIZE 1024
+#define MAX_LINE_TOTAL 512
+#define MAX_CLIENT_BUF 8192
 #define TIMEOUT_MS 50
 #define PING_INTERVAL 180
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -5,7 +5,7 @@ Client::Client()
 	_nickname(""), _username(""), _realname(""),
 	_passReceived(false), _nickReceived(false), _userReceived(false),
 	_isRegistered(false), _isOperator(false),
-	_lastPingTime(0), _lastPingToken("")
+	_lastPingTime(time(NULL)), _lastPingToken("")
 {
 	_pfd.fd = 0;
 	_pfd.events = 0;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -91,10 +91,7 @@ void	Server::run(void)
 					handleClientInput(_poll_fds[i].fd);
 			}
 			if ((_poll_fds[i].revents & POLLHUP) && _poll_fds[i].fd != _server_fd)
-			{
 				handleClientInput(_poll_fds[i].fd);
-				disconnectClient(_poll_fds[i].fd);
-			}
 		}
 
 		checkClientTimeout();
@@ -250,7 +247,7 @@ bool	Server::executeCmdLine(int fd, const std::string & msg)
 	for (int i = 0; i < (int)parsed.args.size(); ++i)
 	{
 		std::cerr << "[" << i << "]";
-		printlog.print_debug("ARGUMENTS: " + parsed.args[i]);
+		printlog.print_debug("ARGUMENT: " + parsed.args[i]);
 	}
 
 	if (!client->getIsRegistered())

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -419,7 +419,6 @@ void	Server::sendPing(void)
 		std::string	ping = "PING :" + token + "\r\n";
 		sendAllNonBlocking(fd, ping.c_str(), ping.size());
 		it->second.setLastPingToken(token);
-		it->second.setLastPingTime(time(NULL));
 	}
 	return ;
 }


### PR DESCRIPTION
## 概要 <!-- 何をやりましたか？ -->
- ソケットをノンブロッキング化
    - `fcntl(fd, F_SETFL, O_NONBLOCK)` をサーバとクライアント両方に適用
- `SIGPIPE` 対応    
    - `SIGPIPE` を無視：`signal(SIGPIPE, SIG_IGN)`
- `poll` 駆動のイベント処理を安全化
    - `POLLHUP` / `POLLERR` / `POLLNVAL` を処理を分岐
    - `poll` 配列を逆順走査して、disconnectClientでfdを削除した時の取りこぼしを防止
- `handleClientInput` のリファクタ
    - `readFromSocket`：ノンブロッキングでソケットから読めるだけ受信して、クライアントバッファに貯める
    - `extractClientBufferLine`：バッファから改行区切りで1行として取り出し、CRLFを除去、長過ぎる行はエラー通知
    - `executeCmdLine`：Parserでパース、コマンドを実行、レスポンス送信
- `sendAllNonBlocking` で送信時にサーバが止まらないように対応

## 動作確認方法 <!-- どのように確認(テスト)すればいいですか？ -->


## 補足 <!-- レビュワーに伝えたい追加情報や懸念点があれば記載してください -->
- `poll`について（ざっくり）
    - たくさんのソケットをまとめて見張って、今すぐ処理すべきソケットだけを教えてくれる
    - 監視している`fd`に対し、発生したイベントの種類（`POLLIN`, `POLLHUP`, `POLLERR`, `POLLNVAL`）を`revents` に立てて返す
- この実装での`poll`の動作
    - pollで待つ（最大50msの間ソケットを見張る）
    - 返ってきたら revents を見る
        - `POLLIN` または `POLLERR` はエラーなので切断
        - サーバFD + POLLIN（読み込み可）：`acceptNewClient` で新規接続をまとめて受ける
        - クライアントFD + POLLIN（読み込み可）：`handleClientInput` で入力内容を処理
         - クライアントFD + POLLHUP ならソケットに残ってるデータを処理してから切断
- ノンブロッキング + `poll` のおかげで、1つの遅いクライアントがいてもサーバ全体が止めないで処理することができる

- `sendAllNonBlocking` について
    - `send` はクライアントの受信が遅いとバッファが埋まり、ブロックまたは`EAGAIN`/`EWOULDBLOCK`で失敗する
    - サーバが停止しないように、「今送れる分を送れるだけ送って、詰まったらその時点でやめてメインのループに戻る」処理を`sendAllNonBlocking`で行ってる

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [x] コンパイルできますか？
+ [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [x] セグフォ・リーク・free忘れはありませんか？
