### PR TITLE
107-port番号チェック

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,11 @@ int	main(int argc, char *argv[])
 		std::cerr << "Error: password must not be empty" << std::endl;
 		return (1);
 	}
+	if (password.find_first_of(" \t\r\n\v\f") != std::string::npos)
+    {
+        std::cerr << "Error: password must not contain whitespace" << std::endl;
+        return (1);
+    }
 
 	Server	server(static_cast<int>(port), password);
 	server.run();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,10 +8,28 @@ int	main(int argc, char *argv[])
 		return (1);
 	}
 
-	int			port = atoi(argv[1]);
-	std::string	password = argv[2];
+	errno = 0;
+	char	*end = 0;
+	long	port = std::strtol(argv[1], &end, 10);
+	if (errno == ERANGE || end == argv[1] || *end != '\0')
+	{
+		std::cerr << "Error: invalid port number. Use 1 - 65535" << std::endl;
+		return (1);
+	}
+	if (port < 1 || port > 65535)
+	{
+		std::cerr << "Error: port out of range. Use 1-65535" << std::endl;
+		return (1);
+	}
 
-	Server	server(port, password);
+	std::string	password = argv[2];
+	if (password.empty())
+	{
+		std::cerr << "Error: password must not be empty" << std::endl;
+		return (1);
+	}
+
+	Server	server(static_cast<int>(port), password);
 	server.run();
 	return (0);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@ int	main(int argc, char *argv[])
 	long	port = std::strtol(argv[1], &end, 10);
 	if (errno == ERANGE || end == argv[1] || *end != '\0')
 	{
-		std::cerr << "Error: invalid port number. Use 1 - 65535" << std::endl;
+		std::cerr << "Error: invalid port number. Use 1-65535" << std::endl;
 		return (1);
 	}
 	if (port < 1 || port > 65535)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,8 +30,8 @@ int	main(int argc, char *argv[])
 	}
 	if (password.find_first_of(" \t\r\n\v\f") != std::string::npos)
     {
-        std::cerr << "Error: password must not contain whitespace" << std::endl;
-        return (1);
+		std::cerr << "Error: password must not contain whitespace" << std::endl;
+		return (1);
     }
 
 	Server	server(static_cast<int>(port), password);


### PR DESCRIPTION
## 概要 <!-- 何をやりましたか？ -->
- 入力バリデーション強化: ポート番号のチェックと空パスワードの拒否
- `if (errno == ERANGE || end == argv[1] || *end != '\0')`
    - `errno == ERANGE`：オーバーフロー / アンダーフロー
    - `end == argv[1]`：入力行を1桁も読めなかった（未入力 or 数ではない）
    - `*end != '\0'`：入力行の最後がヌルではない
- `if (port < 1 || port > 65535)` ：ポート番号の範囲チェック
- `if (password.empty())`：空パスワードを拒否
- `if (password.find_first_of(" \t\r\n\v\f") != std::string::npos)`：空白を含むパスワードの拒否

## 動作確認方法 <!-- どのように確認(テスト)すればいいですか？ -->
- ポート番号に文字が入ってる
```
./ircserv 655abc pass
Error: invalid port number. Use 1 - 65535
```
- ボート番号の範囲を超えてる
```
./ircserv 65536 pass
Error: port out of range. Use 1-65535
```
- パスワードが空
```
./ircserv 6667 ""
Error: password must not be empty
```
- パスワードが空白のみ
```
./ircserv 6667 " "
Error: password must not contain whitespace
```
- パスワードが空白を含む
```
./ircserv 6667 "pass   "
Error: password must not contain whitespace
```

## 補足 <!-- レビュワーに伝えたい追加情報や懸念点があれば記載してください -->


### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [x] コンパイルできますか？
+ [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [x] セグフォ・リーク・free忘れはありませんか？
